### PR TITLE
Fix using useRouterHistory before declaration

### DIFF
--- a/todo/js/app.js
+++ b/todo/js/app.js
@@ -21,9 +21,9 @@ import TodoList from './components/TodoList';
 import ViewerQueries from './queries/ViewerQueries';
 
 import {createHashHistory} from 'history';
+import {applyRouterMiddleware, useRouterHistory} from 'react-router';
 const history = useRouterHistory(createHashHistory)({ queryKey: false });
 const mountNode = document.getElementById('root');
-import {applyRouterMiddleware, useRouterHistory} from 'react-router';
 import useRelay from 'react-router-relay';
 
 ReactDOM.render(


### PR DESCRIPTION
`useRouterHistory` was used before importing from `react-router`, at line 24.  This PR solved that issue by importing needed functions once at the top of the file.