### PR TITLE
add watchman config to watch .js files

### DIFF
--- a/todo-modern/.watchmanconfig
+++ b/todo-modern/.watchmanconfig
@@ -1,0 +1,1 @@
+{"root_files":[".js"]}


### PR DESCRIPTION
Without `.watchmanconfig` file that lists `.js` files as root files, `npm run build` does now work for me. This can be reproduced by running `watchman shutdown-server` and then running `npm run build`.

Not sure if this is a good fix - feel free to disregard if not.