### PR TITLE
Adding clientMutationId to more mutations

### DIFF
--- a/todo-modern/js/mutations/ChangeTodoStatusMutation.js
+++ b/todo-modern/js/mutations/ChangeTodoStatusMutation.js
@@ -48,6 +48,8 @@ function getOptimisticResponse(complete, todo, user) {
   };
 }
 
+let tempID = 0;
+
 function commit(
   environment,
   complete,
@@ -59,7 +61,11 @@ function commit(
     {
       mutation,
       variables: {
-        input: {complete, id: todo.id},
+        input: {
+          complete,
+          id: todo.id,
+          clientMutationId: tempID++,
+        },
       },
       optimisticResponse: () => getOptimisticResponse(complete, todo, user),
     }

--- a/todo-modern/js/mutations/MarkAllTodosMutation.js
+++ b/todo-modern/js/mutations/MarkAllTodosMutation.js
@@ -50,6 +50,8 @@ function getOptimisticResponse(complete, todos, user) {
   };
 }
 
+let tempID = 0;
+
 function commit(
   environment,
   complete,
@@ -61,7 +63,10 @@ function commit(
     {
       mutation,
       variables: {
-        input: {complete},
+        input: {
+          complete,
+          clientMutationId: tempID++,
+        },
       },
       optimisticResponse: () => getOptimisticResponse(complete, todos, user),
     }

--- a/todo-modern/js/mutations/RemoveCompletedTodosMutation.js
+++ b/todo-modern/js/mutations/RemoveCompletedTodosMutation.js
@@ -39,6 +39,8 @@ function sharedUpdater(store, user, deletedIDs) {
   );
 }
 
+let tempID = 0;
+
 function commit(
   environment,
   todos,
@@ -49,7 +51,9 @@ function commit(
     {
       mutation,
       variables: {
-        input: {},
+        input: {
+          clientMutationId: tempID++,
+        },
       },
       updater: (store) => {
         const payload = store.getRootField('removeCompletedTodos');

--- a/todo-modern/js/mutations/RemoveTodoMutation.js
+++ b/todo-modern/js/mutations/RemoveTodoMutation.js
@@ -40,6 +40,8 @@ function sharedUpdater(store, user, deletedID) {
   );
 }
 
+let tempID = 0;
+
 function commit(
   environment,
   todo,
@@ -50,7 +52,10 @@ function commit(
     {
       mutation,
       variables: {
-        input: {id: todo.id},
+        input: {
+          id: todo.id,
+          clientMutationId: tempID++,
+        },
       },
       updater: (store) => {
         const payload = store.getRootField('removeTodo');

--- a/todo-modern/js/mutations/RenameTodoMutation.js
+++ b/todo-modern/js/mutations/RenameTodoMutation.js
@@ -37,6 +37,8 @@ function getOptimisticResponse(text, todo) {
   };
 }
 
+let tempID = 0;
+
 function commit(
   environment,
   text,
@@ -47,7 +49,11 @@ function commit(
     {
       mutation,
       variables: {
-        input: {text, id: todo.id},
+        input: {
+          text,
+          id: todo.id,
+          clientMutationId: tempID++,
+        },
       },
       optimisticResponse: () => getOptimisticResponse(text, todo),
     }


### PR DESCRIPTION
Building off of [commit ed955945ca5158ac34ed8ce703ae0cc7cb3e38e7](https://github.com/relayjs/relay-examples/commit/ed955945ca5158ac34ed8ce703ae0cc7cb3e38e7).  This does not seem to be necessary for this implementation, but I am using it as reference code for a Golang backend version.  In the Golang version, `clientMutationId` is a required input.  According to the `GraphQL` docs, this parameter is [required](https://facebook.github.io/relay/graphql/mutations.htm).