### PR TITLE
Fix optimisticUpdater

### DIFF
--- a/todo/js/components/TodoListFooter.js
+++ b/todo/js/components/TodoListFooter.js
@@ -20,9 +20,12 @@ import {
 
 class TodoListFooter extends React.Component {
   _handleRemoveCompletedTodosClick = () => {
+    const edges = this.props.viewer.todos.edges.filter(edge => edge.node.complete === true);
     RemoveCompletedTodosMutation.commit(
       this.props.relay.environment,
-      this.props.viewer.completedTodos,
+      {
+        edges,
+      },
       this.props.viewer,
     );
   };
@@ -52,10 +55,9 @@ export default createFragmentContainer(
     fragment TodoListFooter_viewer on User {
       id,
       completedCount,
-      completedTodos: todos(
-        status: "completed",
+      todos(
         first: 2147483647  # max GraphQLInt
-      ) {
+      ) @connection(key: "TodoList_todos") {
         edges {
           node {
             id


### PR DESCRIPTION
Closes #69 per conversation on facebook/relay/issues/2345.

- Share the same connection key with `TodoList` to keep the data up to date.
- Dynamically compute `completedTodos` to make sure RemoveCompletedTodosMutation receive correct parameters.