### PR TITLE
start command runs app even if relay compiler errors

### DIFF
--- a/issue-tracker/package.json
+++ b/issue-tracker/package.json
@@ -16,7 +16,7 @@
     "relay-runtime": "^7.0.0"
   },
   "scripts": {
-    "start": "yarn run relay && concurrently --kill-others --names \"react-scripts,relay\" \"react-scripts start\" \"yarn run relay --watch\"",
+    "start": "yarn run relay || concurrently --kill-others --names \"react-scripts,relay\" \"react-scripts start\" \"yarn run relay --watch\"",
     "build": "yarn run relay && react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",


### PR DESCRIPTION
The start command currently runs Relay Compiler in batch mode first, to make sure that generated artifacts are up to date, and then runs the compiler in watch mode concurrently with `react-scripts start`. This avoids order-of-operations issues where react-scripts starts up before the generated code from the compiler is ready. However, if the compiler fails - which can happen for an invalid query or for invalid JS source code - that previously caused the command to fail on the command line. The change here tries running the compiler, but if it fails falls through to react-scripts, which will show the error directly in the user's browser and be able to update when the user fixes the problem.