### PR TITLE
Issue comments w pagination

### DIFF
--- a/issue-tracker/package.json
+++ b/issue-tracker/package.json
@@ -16,7 +16,7 @@
     "relay-runtime": "^7.0.0"
   },
   "scripts": {
-    "start": "yarn run relay || concurrently --kill-others --names \"react-scripts,relay\" \"react-scripts start\" \"yarn run relay --watch\"",
+    "start": "yarn run relay; concurrently --kill-others --names \"react-scripts,relay\" \"react-scripts start\" \"yarn run relay --watch\"",
     "build": "yarn run relay && react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",

--- a/issue-tracker/src/IssueDetailComments.js
+++ b/issue-tracker/src/IssueDetailComments.js
@@ -1,0 +1,105 @@
+import graphql from 'babel-plugin-relay/macro';
+import React from 'react';
+import { usePaginationFragment } from 'react-relay/hooks';
+import ReactMarkdown from 'react-markdown';
+import SuspenseImage from './SuspenseImage';
+
+const { useCallback, useTransition, Suspense, SuspenseList } = React;
+
+const SUSPENSE_CONFIG = { timeoutMs: 2000 };
+
+/**
+ * Renders a list of issues for a given repository.
+ */
+export default function IssueDetailComments(props) {
+  // Given a reference to an issue in props.issue, defines *what*
+  // data the component needs about that repository. In this case we fetch
+  // the list of comments starting at a given cursor (initially null to start
+  // at the beginning of the issues list). See the usePaginationFragment()
+  // docs: https://relay.dev/docs/en/experimental/api-reference#usepaginationfragment
+  // for more details about how to use this hook to paginate over lists.
+  const { data, hasNext, loadNext, isLoadingNext } = usePaginationFragment(
+    graphql`
+      fragment IssueDetailComments_issue on Issue
+        @argumentDefinitions(
+          cursor: { type: "String" }
+          count: { type: "Int", defaultValue: 10 }
+        )
+        @refetchable(queryName: "IssueDetailCommentsQuery") {
+        comments(after: $cursor, first: $count)
+          @connection(key: "IssueDetailComments_comments") {
+          edges {
+            __id
+            node {
+              id
+              author {
+                login
+                avatarUrl
+              }
+              body
+            }
+          }
+        }
+      }
+    `,
+    props.issue,
+  );
+  const [startTransition, isPending] = useTransition(SUSPENSE_CONFIG);
+
+  // Callback to paginate the issues list
+  const loadMore = useCallback(() => {
+    // Don't fetch again if we're already loading the next page
+    if (isLoadingNext) {
+      return;
+    }
+    startTransition(() => {
+      loadNext(10);
+    });
+  }, [isLoadingNext, loadNext, startTransition]);
+
+  const comments = data.comments.edges;
+  if (comments == null || comments.length === 0) {
+    return <div className="issue-no-comments">No comments</div>;
+  }
+
+  return (
+    <SuspenseList revealOrder="forwards">
+      {comments.map(edge => {
+        if (edge == null || edge.node == null) {
+          return null;
+        }
+        const comment = edge.node;
+        return (
+          <Suspense fallback={null}>
+            <div className="issue-comment" key={edge.__id}>
+              <SuspenseImage
+                className="issue-comment-author-image"
+                title={`${comment.author.login}'s avatar`}
+                src={comment.author.avatarUrl}
+              />
+              <div className="issue-comment-author-name">
+                {comment.author.login}
+              </div>
+              <div className="issue-comment-body">
+                <ReactMarkdown
+                  source={comment.body}
+                  renderers={{ image: SuspenseImage }}
+                />
+              </div>
+            </div>
+          </Suspense>
+        );
+      })}
+      {hasNext ? (
+        <button
+          name="load more comments"
+          type="button"
+          className="issue-comments-load-more"
+          onClick={loadMore}
+        >
+          {isPending || isLoadingNext ? 'Loading...' : 'Load More'}
+        </button>
+      ) : null}
+    </SuspenseList>
+  );
+}

--- a/issue-tracker/src/IssueDetailRoot.js
+++ b/issue-tracker/src/IssueDetailRoot.js
@@ -2,6 +2,8 @@ import React from 'react';
 import graphql from 'babel-plugin-relay/macro';
 import { usePreloadedQuery } from 'react-relay/hooks';
 import ReactMarkdown from 'react-markdown';
+import SuspenseImage from './SuspenseImage';
+import IssueDetailComments from './IssueDetailComments';
 
 /**
  * The root component for the issue detail route.
@@ -26,9 +28,12 @@ export default function IssueDetailRoot(props) {
             number
             author {
               login
+              avatarUrl
             }
             body
             closed
+            url
+            ...IssueDetailComments_issue
           }
         }
       }
@@ -48,11 +53,31 @@ export default function IssueDetailRoot(props) {
         <div className="issue">
           <div className="issue-title">
             #{issue.number} - {issue.title} - {issue.closed ? 'Closed' : 'Open'}
+            <a
+              className="issue-title-github-link"
+              href={issue.url}
+              title="Issue on GitHub"
+            >
+              View on GitHub
+            </a>
           </div>
-          <div className="issue-author">@{issue.author.login}</div>
-          <div className="issue-body">
-            <ReactMarkdown source={issue.body} />
+          <div className="issue-comment">
+            <SuspenseImage
+              className="issue-comment-author-image"
+              title={`${issue.author.login}'s avatar`}
+              src={issue.author.avatarUrl}
+            />
+            <div className="issue-comment-author-name">
+              {issue.author.login}
+            </div>
+            <div className="issue-comment-body">
+              <ReactMarkdown
+                source={issue.body}
+                renderers={{ image: SuspenseImage }}
+              />
+            </div>
           </div>
+          <IssueDetailComments issue={issue} />
         </div>
       </section>
     </div>

--- a/issue-tracker/src/JSResource.js
+++ b/issue-tracker/src/JSResource.js
@@ -24,19 +24,18 @@ class Resource {
   load() {
     let promise = this._promise;
     if (promise == null) {
-      promise = this._loader().then(
-        result => {
+      promise = this._loader()
+        .then(result => {
           if (result.default) {
             result = result.default;
           }
           this._result = result;
           return result;
-        },
-        error => {
+        })
+        .catch(error => {
           this._error = error;
           throw error;
-        },
-      );
+        });
       this._promise = promise;
     }
     return promise;

--- a/issue-tracker/src/SuspenseImage.js
+++ b/issue-tracker/src/SuspenseImage.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import JSResource from './JSResource';
+
+export default function SuspenseImage(props) {
+  console.log(props);
+  const { src } = props;
+  if (src != null) {
+    const resource = JSResource(src, () => {
+      return new Promise(resolve => {
+        const img = new Image();
+        img.onload = () => {
+          resolve(src);
+        };
+        img.src = src;
+      });
+    });
+    resource.load();
+    resource.read();
+  }
+  return <img alt={props.alt} {...props} />;
+}

--- a/issue-tracker/src/SuspenseImage.js
+++ b/issue-tracker/src/SuspenseImage.js
@@ -5,6 +5,12 @@ export default function SuspenseImage(props) {
   console.log(props);
   const { src } = props;
   if (src != null) {
+    // JSResource is meant for loading resources, but the implementation is
+    // just cached loading of promises. So we reuse that here as a quick
+    // way to suspend while images are loading, with caching in case
+    // we encouter the same image twice (in that case, we'll create
+    // new loader *functions*, but JSResource will return a cached
+    // value and only load the iamge once.
     const resource = JSResource(src, () => {
       return new Promise(resolve => {
         const img = new Image();
@@ -14,8 +20,8 @@ export default function SuspenseImage(props) {
         img.src = src;
       });
     });
-    resource.load();
-    resource.read();
+    resource.load(); // TODO: JSResource::read() should call load() if necessary
+    resource.read(); // suspends while the image is pending
   }
   return <img alt={props.alt} {...props} />;
 }

--- a/issue-tracker/src/__generated__/IssueDetailCommentsQuery.graphql.js
+++ b/issue-tracker/src/__generated__/IssueDetailCommentsQuery.graphql.js
@@ -1,0 +1,324 @@
+/**
+ * @flow
+ * @relayHash dd3fa1f8fd5623331d1137219fb1b091
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest } from 'relay-runtime';
+type IssueDetailComments_issue$ref = any;
+export type IssueDetailCommentsQueryVariables = {|
+  cursor?: ?string,
+  count?: ?number,
+  id: string,
+|};
+export type IssueDetailCommentsQueryResponse = {|
+  +node: ?{|
+    +$fragmentRefs: IssueDetailComments_issue$ref
+  |}
+|};
+export type IssueDetailCommentsQuery = {|
+  variables: IssueDetailCommentsQueryVariables,
+  response: IssueDetailCommentsQueryResponse,
+|};
+*/
+
+/*
+query IssueDetailCommentsQuery(
+  $cursor: String
+  $count: Int = 10
+  $id: ID!
+) {
+  node(id: $id) {
+    __typename
+    ...IssueDetailComments_issue_1G22uz
+    id
+  }
+}
+
+fragment IssueDetailComments_issue_1G22uz on Issue {
+  comments(after: $cursor, first: $count) {
+    edges {
+      node {
+        id
+        author {
+          __typename
+          login
+          avatarUrl
+          ... on Node {
+            id
+          }
+        }
+        body
+        __typename
+      }
+      cursor
+    }
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
+  }
+  id
+}
+*/
+
+const node /*: ConcreteRequest*/ = (function() {
+  var v0 = [
+      {
+        kind: 'LocalArgument',
+        name: 'cursor',
+        type: 'String',
+        defaultValue: null,
+      },
+      {
+        kind: 'LocalArgument',
+        name: 'count',
+        type: 'Int',
+        defaultValue: 10,
+      },
+      {
+        kind: 'LocalArgument',
+        name: 'id',
+        type: 'ID!',
+        defaultValue: null,
+      },
+    ],
+    v1 = [
+      {
+        kind: 'Variable',
+        name: 'id',
+        variableName: 'id',
+      },
+    ],
+    v2 = {
+      kind: 'ScalarField',
+      alias: null,
+      name: '__typename',
+      args: null,
+      storageKey: null,
+    },
+    v3 = {
+      kind: 'ScalarField',
+      alias: null,
+      name: 'id',
+      args: null,
+      storageKey: null,
+    },
+    v4 = [
+      {
+        kind: 'Variable',
+        name: 'after',
+        variableName: 'cursor',
+      },
+      {
+        kind: 'Variable',
+        name: 'first',
+        variableName: 'count',
+      },
+    ];
+  return {
+    kind: 'Request',
+    fragment: {
+      kind: 'Fragment',
+      name: 'IssueDetailCommentsQuery',
+      type: 'Query',
+      metadata: null,
+      argumentDefinitions: (v0 /*: any*/),
+      selections: [
+        {
+          kind: 'LinkedField',
+          alias: null,
+          name: 'node',
+          storageKey: null,
+          args: (v1 /*: any*/),
+          concreteType: null,
+          plural: false,
+          selections: [
+            {
+              kind: 'FragmentSpread',
+              name: 'IssueDetailComments_issue',
+              args: [
+                {
+                  kind: 'Variable',
+                  name: 'count',
+                  variableName: 'count',
+                },
+                {
+                  kind: 'Variable',
+                  name: 'cursor',
+                  variableName: 'cursor',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    operation: {
+      kind: 'Operation',
+      name: 'IssueDetailCommentsQuery',
+      argumentDefinitions: (v0 /*: any*/),
+      selections: [
+        {
+          kind: 'LinkedField',
+          alias: null,
+          name: 'node',
+          storageKey: null,
+          args: (v1 /*: any*/),
+          concreteType: null,
+          plural: false,
+          selections: [
+            (v2 /*: any*/),
+            (v3 /*: any*/),
+            {
+              kind: 'InlineFragment',
+              type: 'Issue',
+              selections: [
+                {
+                  kind: 'LinkedField',
+                  alias: null,
+                  name: 'comments',
+                  storageKey: null,
+                  args: (v4 /*: any*/),
+                  concreteType: 'IssueCommentConnection',
+                  plural: false,
+                  selections: [
+                    {
+                      kind: 'LinkedField',
+                      alias: null,
+                      name: 'edges',
+                      storageKey: null,
+                      args: null,
+                      concreteType: 'IssueCommentEdge',
+                      plural: true,
+                      selections: [
+                        {
+                          kind: 'LinkedField',
+                          alias: null,
+                          name: 'node',
+                          storageKey: null,
+                          args: null,
+                          concreteType: 'IssueComment',
+                          plural: false,
+                          selections: [
+                            (v3 /*: any*/),
+                            {
+                              kind: 'LinkedField',
+                              alias: null,
+                              name: 'author',
+                              storageKey: null,
+                              args: null,
+                              concreteType: null,
+                              plural: false,
+                              selections: [
+                                (v2 /*: any*/),
+                                {
+                                  kind: 'ScalarField',
+                                  alias: null,
+                                  name: 'login',
+                                  args: null,
+                                  storageKey: null,
+                                },
+                                {
+                                  kind: 'ScalarField',
+                                  alias: null,
+                                  name: 'avatarUrl',
+                                  args: null,
+                                  storageKey: null,
+                                },
+                                (v3 /*: any*/),
+                              ],
+                            },
+                            {
+                              kind: 'ScalarField',
+                              alias: null,
+                              name: 'body',
+                              args: null,
+                              storageKey: null,
+                            },
+                            (v2 /*: any*/),
+                          ],
+                        },
+                        {
+                          kind: 'ScalarField',
+                          alias: null,
+                          name: 'cursor',
+                          args: null,
+                          storageKey: null,
+                        },
+                        {
+                          kind: 'ClientExtension',
+                          selections: [
+                            {
+                              kind: 'ScalarField',
+                              alias: null,
+                              name: '__id',
+                              args: null,
+                              storageKey: null,
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                    {
+                      kind: 'LinkedField',
+                      alias: null,
+                      name: 'pageInfo',
+                      storageKey: null,
+                      args: null,
+                      concreteType: 'PageInfo',
+                      plural: false,
+                      selections: [
+                        {
+                          kind: 'ScalarField',
+                          alias: null,
+                          name: 'endCursor',
+                          args: null,
+                          storageKey: null,
+                        },
+                        {
+                          kind: 'ScalarField',
+                          alias: null,
+                          name: 'hasNextPage',
+                          args: null,
+                          storageKey: null,
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  kind: 'LinkedHandle',
+                  alias: null,
+                  name: 'comments',
+                  args: (v4 /*: any*/),
+                  handle: 'connection',
+                  key: 'IssueDetailComments_comments',
+                  filters: null,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    params: {
+      operationKind: 'query',
+      name: 'IssueDetailCommentsQuery',
+      id: null,
+      text:
+        'query IssueDetailCommentsQuery(\n  $cursor: String\n  $count: Int = 10\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...IssueDetailComments_issue_1G22uz\n    id\n  }\n}\n\nfragment IssueDetailComments_issue_1G22uz on Issue {\n  comments(after: $cursor, first: $count) {\n    edges {\n      node {\n        id\n        author {\n          __typename\n          login\n          avatarUrl\n          ... on Node {\n            id\n          }\n        }\n        body\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n',
+      metadata: {
+        derivedFrom: 'IssueDetailComments_issue',
+        isRefetchableQuery: true,
+      },
+    },
+  };
+})();
+// prettier-ignore
+(node/*: any*/).hash = '674952f209c2653f27a5fad5539df511';
+module.exports = node;

--- a/issue-tracker/src/__generated__/IssueDetailComments_issue.graphql.js
+++ b/issue-tracker/src/__generated__/IssueDetailComments_issue.graphql.js
@@ -1,0 +1,211 @@
+/**
+ * @flow
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ReaderFragment } from 'relay-runtime';
+import type { FragmentReference } from "relay-runtime";
+declare export opaque type IssueDetailComments_issue$ref: FragmentReference;
+declare export opaque type IssueDetailComments_issue$fragmentType: IssueDetailComments_issue$ref;
+export type IssueDetailComments_issue = {|
+  +comments: {|
+    +edges: ?$ReadOnlyArray<?{|
+      +__id: string,
+      +node: ?{|
+        +id: string,
+        +author: ?{|
+          +login: string,
+          +avatarUrl: any,
+        |},
+        +body: string,
+      |},
+    |}>
+  |},
+  +id: ?string,
+  +$refType: IssueDetailComments_issue$ref,
+|};
+export type IssueDetailComments_issue$data = IssueDetailComments_issue;
+export type IssueDetailComments_issue$key = {
+  +$data?: IssueDetailComments_issue$data,
+  +$fragmentRefs: IssueDetailComments_issue$ref,
+};
+*/
+
+const node /*: ReaderFragment*/ = (function() {
+  var v0 = ['comments'],
+    v1 = {
+      kind: 'ScalarField',
+      alias: null,
+      name: 'id',
+      args: null,
+      storageKey: null,
+    };
+  return {
+    kind: 'Fragment',
+    name: 'IssueDetailComments_issue',
+    type: 'Issue',
+    metadata: {
+      connection: [
+        {
+          count: 'count',
+          cursor: 'cursor',
+          direction: 'forward',
+          path: (v0 /*: any*/),
+        },
+      ],
+      refetch: {
+        connection: {
+          forward: {
+            count: 'count',
+            cursor: 'cursor',
+          },
+          backward: null,
+          path: (v0 /*: any*/),
+        },
+        operation: require('./IssueDetailCommentsQuery.graphql.js'),
+        fragmentPathInResult: ['node'],
+      },
+    },
+    argumentDefinitions: [
+      {
+        kind: 'LocalArgument',
+        name: 'cursor',
+        type: 'String',
+        defaultValue: null,
+      },
+      {
+        kind: 'LocalArgument',
+        name: 'count',
+        type: 'Int',
+        defaultValue: 10,
+      },
+    ],
+    selections: [
+      {
+        kind: 'LinkedField',
+        alias: 'comments',
+        name: '__IssueDetailComments_comments_connection',
+        storageKey: null,
+        args: null,
+        concreteType: 'IssueCommentConnection',
+        plural: false,
+        selections: [
+          {
+            kind: 'LinkedField',
+            alias: null,
+            name: 'edges',
+            storageKey: null,
+            args: null,
+            concreteType: 'IssueCommentEdge',
+            plural: true,
+            selections: [
+              {
+                kind: 'LinkedField',
+                alias: null,
+                name: 'node',
+                storageKey: null,
+                args: null,
+                concreteType: 'IssueComment',
+                plural: false,
+                selections: [
+                  (v1 /*: any*/),
+                  {
+                    kind: 'LinkedField',
+                    alias: null,
+                    name: 'author',
+                    storageKey: null,
+                    args: null,
+                    concreteType: null,
+                    plural: false,
+                    selections: [
+                      {
+                        kind: 'ScalarField',
+                        alias: null,
+                        name: 'login',
+                        args: null,
+                        storageKey: null,
+                      },
+                      {
+                        kind: 'ScalarField',
+                        alias: null,
+                        name: 'avatarUrl',
+                        args: null,
+                        storageKey: null,
+                      },
+                    ],
+                  },
+                  {
+                    kind: 'ScalarField',
+                    alias: null,
+                    name: 'body',
+                    args: null,
+                    storageKey: null,
+                  },
+                  {
+                    kind: 'ScalarField',
+                    alias: null,
+                    name: '__typename',
+                    args: null,
+                    storageKey: null,
+                  },
+                ],
+              },
+              {
+                kind: 'ScalarField',
+                alias: null,
+                name: 'cursor',
+                args: null,
+                storageKey: null,
+              },
+              {
+                kind: 'ClientExtension',
+                selections: [
+                  {
+                    kind: 'ScalarField',
+                    alias: null,
+                    name: '__id',
+                    args: null,
+                    storageKey: null,
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            kind: 'LinkedField',
+            alias: null,
+            name: 'pageInfo',
+            storageKey: null,
+            args: null,
+            concreteType: 'PageInfo',
+            plural: false,
+            selections: [
+              {
+                kind: 'ScalarField',
+                alias: null,
+                name: 'endCursor',
+                args: null,
+                storageKey: null,
+              },
+              {
+                kind: 'ScalarField',
+                alias: null,
+                name: 'hasNextPage',
+                args: null,
+                storageKey: null,
+              },
+            ],
+          },
+        ],
+      },
+      (v1 /*: any*/),
+    ],
+  };
+})();
+// prettier-ignore
+(node/*: any*/).hash = '674952f209c2653f27a5fad5539df511';
+module.exports = node;

--- a/issue-tracker/src/__generated__/IssueDetailRootQuery.graphql.js
+++ b/issue-tracker/src/__generated__/IssueDetailRootQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash aaa90e4d31366894eab251f5efc57ebf
+ * @relayHash f0aa55683059dc236ee106eadb649ef9
  */
 
 /* eslint-disable */
@@ -9,6 +9,7 @@
 
 /*::
 import type { ConcreteRequest } from 'relay-runtime';
+type IssueDetailComments_issue$ref = any;
 export type IssueDetailRootQueryVariables = {|
   id: string,
   owner: string,
@@ -25,10 +26,13 @@ export type IssueDetailRootQueryResponse = {|
     +title?: string,
     +number?: number,
     +author?: ?{|
-      +login: string
+      +login: string,
+      +avatarUrl: any,
     |},
     +body?: string,
     +closed?: boolean,
+    +url?: any,
+    +$fragmentRefs: IssueDetailComments_issue$ref,
   |},
 |};
 export type IssueDetailRootQuery = {|
@@ -60,15 +64,44 @@ query IssueDetailRootQuery(
       author {
         __typename
         login
+        avatarUrl
         ... on Node {
           id
         }
       }
       body
       closed
+      url
+      ...IssueDetailComments_issue
     }
     id
   }
+}
+
+fragment IssueDetailComments_issue on Issue {
+  comments(first: 10) {
+    edges {
+      node {
+        id
+        author {
+          __typename
+          login
+          avatarUrl
+          ... on Node {
+            id
+          }
+        }
+        body
+        __typename
+      }
+      cursor
+    }
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
+  }
+  id
 }
 */
 
@@ -112,32 +145,38 @@ const node /*: ConcreteRequest*/ = (function() {
       args: null,
       storageKey: null,
     },
-    v3 = [(v2 /*: any*/)],
-    v4 = {
+    v3 = {
       kind: 'ScalarField',
       alias: null,
       name: 'name',
       args: null,
       storageKey: null,
     },
-    v5 = [
+    v4 = [
       {
         kind: 'Variable',
         name: 'id',
         variableName: 'id',
       },
     ],
-    v6 = {
+    v5 = {
       kind: 'ScalarField',
       alias: null,
       name: 'title',
       args: null,
       storageKey: null,
     },
-    v7 = {
+    v6 = {
       kind: 'ScalarField',
       alias: null,
       name: 'number',
+      args: null,
+      storageKey: null,
+    },
+    v7 = {
+      kind: 'ScalarField',
+      alias: null,
+      name: 'avatarUrl',
       args: null,
       storageKey: null,
     },
@@ -158,18 +197,46 @@ const node /*: ConcreteRequest*/ = (function() {
     v10 = {
       kind: 'ScalarField',
       alias: null,
-      name: '__typename',
+      name: 'url',
       args: null,
       storageKey: null,
     },
     v11 = {
       kind: 'ScalarField',
       alias: null,
+      name: '__typename',
+      args: null,
+      storageKey: null,
+    },
+    v12 = {
+      kind: 'ScalarField',
+      alias: null,
       name: 'id',
       args: null,
       storageKey: null,
     },
-    v12 = [(v10 /*: any*/), (v2 /*: any*/), (v11 /*: any*/)];
+    v13 = {
+      kind: 'LinkedField',
+      alias: null,
+      name: 'author',
+      storageKey: null,
+      args: null,
+      concreteType: null,
+      plural: false,
+      selections: [
+        (v11 /*: any*/),
+        (v2 /*: any*/),
+        (v7 /*: any*/),
+        (v12 /*: any*/),
+      ],
+    },
+    v14 = [
+      {
+        kind: 'Literal',
+        name: 'first',
+        value: 10,
+      },
+    ];
   return {
     kind: 'Request',
     fragment: {
@@ -196,9 +263,9 @@ const node /*: ConcreteRequest*/ = (function() {
               args: null,
               concreteType: null,
               plural: false,
-              selections: (v3 /*: any*/),
+              selections: [(v2 /*: any*/)],
             },
-            (v4 /*: any*/),
+            (v3 /*: any*/),
           ],
         },
         {
@@ -206,7 +273,7 @@ const node /*: ConcreteRequest*/ = (function() {
           alias: null,
           name: 'node',
           storageKey: null,
-          args: (v5 /*: any*/),
+          args: (v4 /*: any*/),
           concreteType: null,
           plural: false,
           selections: [
@@ -214,8 +281,8 @@ const node /*: ConcreteRequest*/ = (function() {
               kind: 'InlineFragment',
               type: 'Issue',
               selections: [
+                (v5 /*: any*/),
                 (v6 /*: any*/),
-                (v7 /*: any*/),
                 {
                   kind: 'LinkedField',
                   alias: null,
@@ -224,10 +291,16 @@ const node /*: ConcreteRequest*/ = (function() {
                   args: null,
                   concreteType: null,
                   plural: false,
-                  selections: (v3 /*: any*/),
+                  selections: [(v2 /*: any*/), (v7 /*: any*/)],
                 },
                 (v8 /*: any*/),
                 (v9 /*: any*/),
+                (v10 /*: any*/),
+                {
+                  kind: 'FragmentSpread',
+                  name: 'IssueDetailComments_issue',
+                  args: null,
+                },
               ],
             },
           ],
@@ -256,10 +329,10 @@ const node /*: ConcreteRequest*/ = (function() {
               args: null,
               concreteType: null,
               plural: false,
-              selections: (v12 /*: any*/),
+              selections: [(v11 /*: any*/), (v2 /*: any*/), (v12 /*: any*/)],
             },
-            (v4 /*: any*/),
-            (v11 /*: any*/),
+            (v3 /*: any*/),
+            (v12 /*: any*/),
           ],
         },
         {
@@ -267,30 +340,112 @@ const node /*: ConcreteRequest*/ = (function() {
           alias: null,
           name: 'node',
           storageKey: null,
-          args: (v5 /*: any*/),
+          args: (v4 /*: any*/),
           concreteType: null,
           plural: false,
           selections: [
-            (v10 /*: any*/),
             (v11 /*: any*/),
+            (v12 /*: any*/),
             {
               kind: 'InlineFragment',
               type: 'Issue',
               selections: [
+                (v5 /*: any*/),
                 (v6 /*: any*/),
-                (v7 /*: any*/),
+                (v13 /*: any*/),
+                (v8 /*: any*/),
+                (v9 /*: any*/),
+                (v10 /*: any*/),
                 {
                   kind: 'LinkedField',
                   alias: null,
-                  name: 'author',
-                  storageKey: null,
-                  args: null,
-                  concreteType: null,
+                  name: 'comments',
+                  storageKey: 'comments(first:10)',
+                  args: (v14 /*: any*/),
+                  concreteType: 'IssueCommentConnection',
                   plural: false,
-                  selections: (v12 /*: any*/),
+                  selections: [
+                    {
+                      kind: 'LinkedField',
+                      alias: null,
+                      name: 'edges',
+                      storageKey: null,
+                      args: null,
+                      concreteType: 'IssueCommentEdge',
+                      plural: true,
+                      selections: [
+                        {
+                          kind: 'LinkedField',
+                          alias: null,
+                          name: 'node',
+                          storageKey: null,
+                          args: null,
+                          concreteType: 'IssueComment',
+                          plural: false,
+                          selections: [
+                            (v12 /*: any*/),
+                            (v13 /*: any*/),
+                            (v8 /*: any*/),
+                            (v11 /*: any*/),
+                          ],
+                        },
+                        {
+                          kind: 'ScalarField',
+                          alias: null,
+                          name: 'cursor',
+                          args: null,
+                          storageKey: null,
+                        },
+                        {
+                          kind: 'ClientExtension',
+                          selections: [
+                            {
+                              kind: 'ScalarField',
+                              alias: null,
+                              name: '__id',
+                              args: null,
+                              storageKey: null,
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                    {
+                      kind: 'LinkedField',
+                      alias: null,
+                      name: 'pageInfo',
+                      storageKey: null,
+                      args: null,
+                      concreteType: 'PageInfo',
+                      plural: false,
+                      selections: [
+                        {
+                          kind: 'ScalarField',
+                          alias: null,
+                          name: 'endCursor',
+                          args: null,
+                          storageKey: null,
+                        },
+                        {
+                          kind: 'ScalarField',
+                          alias: null,
+                          name: 'hasNextPage',
+                          args: null,
+                          storageKey: null,
+                        },
+                      ],
+                    },
+                  ],
                 },
-                (v8 /*: any*/),
-                (v9 /*: any*/),
+                {
+                  kind: 'LinkedHandle',
+                  alias: null,
+                  name: 'comments',
+                  args: (v14 /*: any*/),
+                  handle: 'connection',
+                  key: 'IssueDetailComments_comments',
+                  filters: null,
+                },
               ],
             },
           ],
@@ -302,11 +457,11 @@ const node /*: ConcreteRequest*/ = (function() {
       name: 'IssueDetailRootQuery',
       id: null,
       text:
-        'query IssueDetailRootQuery(\n  $id: ID!\n  $owner: String!\n  $name: String!\n) {\n  repository(owner: $owner, name: $name) {\n    owner {\n      __typename\n      login\n      id\n    }\n    name\n    id\n  }\n  node(id: $id) {\n    __typename\n    ... on Issue {\n      title\n      number\n      author {\n        __typename\n        login\n        ... on Node {\n          id\n        }\n      }\n      body\n      closed\n    }\n    id\n  }\n}\n',
+        'query IssueDetailRootQuery(\n  $id: ID!\n  $owner: String!\n  $name: String!\n) {\n  repository(owner: $owner, name: $name) {\n    owner {\n      __typename\n      login\n      id\n    }\n    name\n    id\n  }\n  node(id: $id) {\n    __typename\n    ... on Issue {\n      title\n      number\n      author {\n        __typename\n        login\n        avatarUrl\n        ... on Node {\n          id\n        }\n      }\n      body\n      closed\n      url\n      ...IssueDetailComments_issue\n    }\n    id\n  }\n}\n\nfragment IssueDetailComments_issue on Issue {\n  comments(first: 10) {\n    edges {\n      node {\n        id\n        author {\n          __typename\n          login\n          avatarUrl\n          ... on Node {\n            id\n          }\n        }\n        body\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n',
       metadata: {},
     },
   };
 })();
 // prettier-ignore
-(node/*: any*/).hash = '5a5b32b7de101451a5ad78f570b78027';
+(node/*: any*/).hash = 'eb7a581c8bab5b46c9dafa3a023cfb55';
 module.exports = node;

--- a/issue-tracker/src/index.css
+++ b/issue-tracker/src/index.css
@@ -48,7 +48,8 @@ code {
   padding: 2px 0;
 }
 
-.issues-load-more {
+.issues-load-more,
+.issue-comments-load-more {
   margin-top: 20px;
   padding: 4px 10px;
   background-color: #fff;
@@ -61,11 +62,44 @@ code {
 
 .issue-title {
   font-size: 120%;
-  margin-bottom: 10px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid #282c34;
+}
+
+.issue-title-github-link {
+  float: right;
 }
 
 .issue-author {
-  margin-bottom: 20px;
-  padding-bottom: 10px;
+  margin-bottom: 10px;
+  font-weight: bold;
+}
+
+.issue-comment {
+  padding: 10px 0px;
+  margin-left: 48px;
   border-bottom: 1px solid #282c34;
+}
+
+.issue-comment-body p {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.issue-comment-author-name {
+  font-weight: bold;
+  padding: 8px 0px;
+}
+
+.issue-comment-author-image {
+  float: left;
+  margin-left: -48px;
+  padding-right: 16px;
+  width: 32px;
+  height: 32px;
+}
+
+.issue-no-comments {
+  margin-top: 20px;
+  font-weight: bold;
 }


### PR DESCRIPTION
Shows issue comments, along w avatars for the issue author and comment authors. All images, including those in the issue/comment bodies, are suspense-enabled. This allows demonstrating how to combine `<SuspenseList>` and `useTransition()` in order to show comments one at a time while ensuring that they render in-order (top-down). `useTransition()` isn't strictly necessary here, but it means that pagination will generally show a full page of new items as opposed to possibly showing items one at a time.