### PR TITLE
Preload routes in link

### DIFF
--- a/issue-tracker/src/routing/Link.js
+++ b/issue-tracker/src/routing/Link.js
@@ -9,6 +9,8 @@ const { useCallback, useContext } = React;
  */
 export default function Link(props) {
   const router = useContext(RoutingContext);
+
+  // When the user clicks, change route
   const changeRoute = useCallback(
     event => {
       event.preventDefault();
@@ -16,12 +18,21 @@ export default function Link(props) {
     },
     [props.to, router],
   );
+
+  // Callback to preload just the code for the route:
+  // we pass this to onMouseEnter, which is a weaker signal
+  // that the user *may* navigate to the route.
   const preloadRouteCode = useCallback(() => {
     router.preloadCode(props.to);
   }, [props.to, router]);
+
+  // Callback to preload the code and data for the route:
+  // we pass this to onMouseDown, since this is a stronger
+  // signal that the user will likely complete the navigation
   const preloadRoute = useCallback(() => {
     router.preload(props.to);
   }, [props.to, router]);
+
   return (
     <a
       href={props.to}

--- a/issue-tracker/src/routing/Link.js
+++ b/issue-tracker/src/routing/Link.js
@@ -9,16 +9,26 @@ const { useCallback, useContext } = React;
  */
 export default function Link(props) {
   const router = useContext(RoutingContext);
-  const { history } = router;
-  const onClick = useCallback(
+  const changeRoute = useCallback(
     event => {
       event.preventDefault();
-      history.push(props.to);
+      router.history.push(props.to);
     },
-    [props.to, history],
+    [props.to, router],
   );
+  const preloadRouteCode = useCallback(() => {
+    router.preloadCode(props.to);
+  }, [props.to, router]);
+  const preloadRoute = useCallback(() => {
+    router.preload(props.to);
+  }, [props.to, router]);
   return (
-    <a href={props.to} onClick={onClick}>
+    <a
+      href={props.to}
+      onClick={changeRoute}
+      onMouseEnter={preloadRouteCode}
+      onMouseDown={preloadRoute}
+    >
       {props.children}
     </a>
   );

--- a/issue-tracker/src/routing/createRouter.js
+++ b/issue-tracker/src/routing/createRouter.js
@@ -46,6 +46,16 @@ export default function createRouter(routes, options) {
     get() {
       return currentEntry;
     },
+    preloadCode(pathname) {
+      // preload just the code for a route, without storing the result
+      const matches = matchRoutes(routes, { pathname });
+      matches.forEach(({ route }) => route.component.load());
+    },
+    preload(pathname) {
+      // preload the code and data for a route, without storing the result
+      const matches = matchRoutes(routes, pathname);
+      prepareMatches(matches);
+    },
     subscribe(cb) {
       const id = nextId++;
       const dispose = () => {

--- a/issue-tracker/src/routing/createRouter.js
+++ b/issue-tracker/src/routing/createRouter.js
@@ -48,7 +48,7 @@ export default function createRouter(routes, options) {
     },
     preloadCode(pathname) {
       // preload just the code for a route, without storing the result
-      const matches = matchRoutes(routes, { pathname });
+      const matches = matchRoutes(routes, pathname);
       matches.forEach(({ route }) => route.component.load());
     },
     preload(pathname) {


### PR DESCRIPTION
Enables preloading of routes when a user interacts with a  `<Link/>`  component:
* Mouse enter is a weaker signal that the user may click on the link, so at this point we preload just the code for the route.
* Mouse down is a stronger signal that the user will complete the click, so at this point we fully preload the code and data. 

In local testing on this app, I saw that data started loading about 50-100ms earlier than it would have w/o the `<Link/>` preloading. Not a huge amount - but not nothing! And because this logic is part of the `<Link/>` component, the rest of the app gets the small performance win for free.