### PR TITLE
docs: Update README.md

### DIFF
--- a/todo/README.md
+++ b/todo/README.md
@@ -11,14 +11,14 @@ yarn
 Set up generated files:
 
 ```
-yarn run update-schema
-yarn run build
+yarn update-schema
+yarn build
 ```
 
 Start a local server:
 
 ```
-yarn run start
+yarn start
 ```
 
 ## Developing
@@ -30,9 +30,9 @@ If at any time you make changes to `data/schema.js`, stop the server,
 regenerate `data/schema.graphql`, and restart the server:
 
 ```
-yarn run update-schema
-yarn run build
-yarn run start
+yarn update-schema
+yarn build
+yarn start
 ```
 
 ## License


### PR DESCRIPTION
No need to specify `run` when using `yarn`.

```
➜  todo git:(master) yarn update-schema
yarn run v1.21.1
$ babel-node ./scripts/updateSchema.js
Browserslist: caniuse-lite is outdated. Please run next command `yarn upgrade`
Wrote /Users/haruelrovix/Projects/relay-examples/todo/data/schema.graphql
✨  Done in 4.29s.

➜  todo git:(master) yarn build
yarn run v1.21.1
$ relay-compiler --src ./js/ --schema ./data/schema.graphql --artifactDirectory ./__generated__/relay
HINT: pass --watch to keep watching for changes.

Writing js
Unchanged: 12 files
✨  Done in 3.22s.

➜  todo git:(master) yarn start
yarn run v1.21.1
$ babel-node ./server.js
Browserslist: caniuse-lite is outdated. Please run next command `yarn upgrade`
ℹ ｢wds｣: Project is running at http://localhost:3000/
ℹ ｢wds｣: webpack output is served from /js/
ℹ ｢wds｣: Content not from webpack is served from /public/
ℹ ｢wdm｣: Hash: 257b3c4befe724df5b11
Version: webpack 4.41.3
Time: 1586ms
Built at: 01/11/2020 11:32:56 AM
```