### PR TITLE
Add Github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Tests (Node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x, 15.x]
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install watchman
+        run: >
+          (git clone https://github.com/facebook/watchman.git -b v4.9.0 --depth 1 && \
+            cd watchman && \
+            ./autogen.sh && \
+            ./configure && \
+            make && \
+            sudo make install)
+      - name: Install dependencies
+        run: cd ./todo && yarn install --frozen-lockfile
+      - name: Run lint, build and flow
+        run: cd ./todo && yarn run lint && yarn run update-schema && yarn run build && yarn run flow


### PR DESCRIPTION
We are migrating to github actions from travis

Currently the travis build also has typecheck errors.

Tested on the fork, the errors from the github action are the same:
https://github.com/tyao1/relay-examples/runs/1571830879?check_suite_focus=true
https://travis-ci.org/github/relayjs/relay-examples/jobs/749818377