### PR TITLE
Rename references to old default branch name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ We actively welcome your input via pull requests or issues.
 
 ## Pull Requests
 
-1. Fork the repo and create your branch from `master`.
+1. Fork the repo and create your branch from `main`.
 2. If you haven't already, complete the Contributor License Agreement ("CLA").
 
 ## Contributor License Agreement ("CLA")
@@ -23,4 +23,4 @@ Ask questions, provide feedback, or open new topics for discussion by [opening a
 
 ## License
 
-By contributing to relay-examples, you agree that your contributions will be licensed under the terms described in [LICENSE.md](https://github.com/relayjs/relay-examples/blob/master/LICENSE.md).
+By contributing to relay-examples, you agree that your contributions will be licensed under the terms described in [LICENSE.md](https://github.com/relayjs/relay-examples/blob/main/LICENSE.md).

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ A collection of example applications using [Relay](https://github.com/facebook/r
 
 # Contributing
 
-See [CONTRIBUTING.md](https://github.com/relayjs/relay-examples/blob/master/CONTRIBUTING.md).
+See [CONTRIBUTING.md](https://github.com/relayjs/relay-examples/blob/main/CONTRIBUTING.md).
 
 # License
 
-See [LICENSE.md](https://github.com/relayjs/relay-examples/blob/master/LICENSE.md).
+See [LICENSE.md](https://github.com/relayjs/relay-examples/blob/main/LICENSE.md).

--- a/todo/public/learn.json
+++ b/todo/public/learn.json
@@ -7,7 +7,7 @@
       {
         "name": "Relay + express-graphql Example",
         "url": "",
-        "source_url": "https://github.com/relayjs/relay-examples/tree/master/todo",
+        "source_url": "https://github.com/relayjs/relay-examples/tree/main/todo",
         "type": "backend"
       }
     ],

--- a/todo/types/react-relay_types.js
+++ b/todo/types/react-relay_types.js
@@ -1259,7 +1259,7 @@ declare module 'react-relay' {
         variables: Variables,
       }> {}
 
-  // https://github.com/facebook/relay/blob/master/packages/relay-runtime/network/RelayNetworkTypes.js
+  // https://github.com/facebook/relay/blob/main/packages/relay-runtime/network/RelayNetworkTypes.js
   /**
    * A cache for saving respones to queries (by id) and variables.
    */


### PR DESCRIPTION
We renamed the default branch, this updates the references.