### PR TITLE
Added Back Button in issue page

### DIFF
--- a/issue-tracker/src/IssueDetailRoot.js
+++ b/issue-tracker/src/IssueDetailRoot.js
@@ -5,6 +5,7 @@ import ReactMarkdown from 'react-markdown';
 import SuspenseImage from './SuspenseImage';
 import IssueDetailComments from './IssueDetailComments';
 import IssueActions from './IssueActions';
+import Link from './routing/Link';
 
 /**
  * The root component for the issue detail route.
@@ -68,6 +69,13 @@ export default function IssueDetailRoot(props) {
       </div>
       <IssueDetailComments issue={issue} />
       <IssueActions issue={issue} />
+      <div className="back-issue">
+        <Link to="/">
+          <button className="back-issue-button" type="button">
+            Back
+          </button>
+        </Link>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Added back button to issue page. 
Currently the close button may be interpreted to close the current view, meaning to go back to list of repositories.
I added a "Back" button to go to the list of repositories to allow the user go to the list of repositories again.

<img width="1652" alt="Screen Shot 2021-10-03 at 16 24 32" src="https://user-images.githubusercontent.com/62782124/135768538-332afea5-2338-4964-9d46-ed3e3c3f623f.png">
