### PR TITLE
Add error handling mechanism for component module loading

### DIFF
--- a/data-driven-dependencies/components/ErrorBoundary.js
+++ b/data-driven-dependencies/components/ErrorBoundary.js
@@ -1,0 +1,20 @@
+import React from 'react';
+
+export default class ErrorBoundary extends React.Component {
+  componentDidCatch(error) {
+    if (!this.props.shouldCatchError || this.props.shouldCatchError(error)) {
+      this.setState({error});
+    }
+  }
+
+  render() {
+    if (this.state && this.state.error) {
+      return this.props.renderError(this.state.error, this._resetError);
+    }
+    return this.props.children;
+  }
+
+  _resetError = () => {
+    this.setState({error: null});
+  };
+}

--- a/data-driven-dependencies/components/LayoutComponents.js
+++ b/data-driven-dependencies/components/LayoutComponents.js
@@ -25,10 +25,11 @@ export function Text(props) {
   return <p className="mt-4 text-xl text-gray-500" {...props}></p>;
 }
 
-export function Button(props) {
+export function Button({size, ...props}) {
+  const sizeClasses = size === 'small' ? 'px-2' : 'py-3 px-8 font-medium';
   return (
     <button
-      className="inline-block text-center bg-indigo-600 border border-transparent rounded-md py-3 px-8 font-medium text-white hover:bg-indigo-700"
+      className={`inline-block text-center bg-indigo-600 border border-transparent rounded-md text-white hover:bg-indigo-700 ${sizeClasses}`}
       {...props}
     />
   );

--- a/data-driven-dependencies/components/RelayMatchContainer.js
+++ b/data-driven-dependencies/components/RelayMatchContainer.js
@@ -1,18 +1,49 @@
+import React from 'react';
 import MatchContainer from 'react-relay/lib/relay-hooks/MatchContainer';
 import moduleLoader from '../lib/moduleLoader';
+import ErrorBoundary from './ErrorBoundary';
+import {Button} from './LayoutComponents';
 
 export default function RelayMatchContainer({match}) {
   return (
-    <MatchContainer
-      match={match}
-      loader={(name) => {
-        const loader = moduleLoader(name);
-        const module = loader.get();
-        if (module != null) {
-          return module;
-        }
-        throw loader.load();
-      }}
-    />
+    <ErrorBoundary
+      shouldCatchError={(error) => error instanceof ModuleLoaderError}
+      renderError={(error, resetError) => (
+        <div className="bg-red-200 rounded-md px-2 py-1 inline-block">
+          Failed to load {error.moduleLoaderName}{' '}
+          <Button
+            size="small"
+            onClick={() => {
+              moduleLoader(error.moduleLoaderName).resetError();
+              resetError();
+            }}>
+            Reload
+          </Button>
+        </div>
+      )}>
+      <MatchContainer
+        match={match}
+        loader={(name) => {
+          const loader = moduleLoader(name);
+          const error = loader.getError();
+          if (error) {
+            throw new ModuleLoaderError(name, error);
+          }
+          const module = loader.get();
+          if (module != null) {
+            return module;
+          }
+          throw loader.load();
+        }}
+      />
+    </ErrorBoundary>
   );
+}
+
+class ModuleLoaderError extends Error {
+  constructor(moduleLoaderName, error) {
+    super('ModuleLoaderError: ' + error.message);
+    this.moduleLoaderName = moduleLoaderName;
+    this.error = error;
+  }
 }


### PR DESCRIPTION
The current data driven dependencies example doesn't handle errors when loading the component chunk gracefully.

One way to test this out is to block the chunk for the `FancyBlogPostPreview` component (http://localhost:3000/_next/static/chunks/components_FancyBlogPostPreview_js.js) in the network tab, and then load more items until we get a fancy blog post. The current behavior causes an infinite amount of retries fetching the component chunk.

In this PR, I added error handling capabilities to the module loader, adding two new methods `getError` and `resetError`, plus handling the error case in the load promise.

This is leveraged in the `RelayMatchContainer` component, where we wrap the component in an error boundary that will display a UI to tell the component failed to load, and a button to reload the component, which attempts to load the component chunk again and re-render the item.

You can test this out by blocking the request for the component chunk (mentioned above), waiting to see the error UI, then unblocking the request and click reload. You should see the component chunk fetched and used to render the item.