### PR TITLE
[Donot merge] intro a buggy comment

### DIFF
--- a/todo/data/schema.graphql
+++ b/todo/data/schema.graphql
@@ -1,63 +1,103 @@
 type Query {
   user(id: String): User
 
-  """Fetches an object given its ID"""
+  """
+  Fetches an object given its ID 🐛
+  """
   node(
-    """The ID of an object"""
+    """
+    The ID of an object
+    """
     id: ID!
   ): Node
 }
 
 type User implements Node {
-  """The ID of an object"""
+  """
+  The ID of an object
+  """
   id: ID!
   userId: String!
-  todos(status: String = "any", after: String, first: Int, before: String, last: Int): TodoConnection
+  todos(
+    status: String = "any"
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): TodoConnection
   totalCount: Int!
   completedCount: Int!
 }
 
-"""An object with an ID"""
+"""
+An object with an ID
+"""
 interface Node {
-  """The id of the object."""
+  """
+  The id of the object.
+  """
   id: ID!
 }
 
-"""A connection to a list of items."""
+"""
+A connection to a list of items.
+"""
 type TodoConnection {
-  """Information to aid in pagination."""
+  """
+  Information to aid in pagination.
+  """
   pageInfo: PageInfo!
 
-  """A list of edges."""
+  """
+  A list of edges.
+  """
   edges: [TodoEdge]
 }
 
-"""Information about pagination in a connection."""
+"""
+Information about pagination in a connection.
+"""
 type PageInfo {
-  """When paginating forwards, are there more items?"""
+  """
+  When paginating forwards, are there more items?
+  """
   hasNextPage: Boolean!
 
-  """When paginating backwards, are there more items?"""
+  """
+  When paginating backwards, are there more items?
+  """
   hasPreviousPage: Boolean!
 
-  """When paginating backwards, the cursor to continue."""
+  """
+  When paginating backwards, the cursor to continue.
+  """
   startCursor: String
 
-  """When paginating forwards, the cursor to continue."""
+  """
+  When paginating forwards, the cursor to continue.
+  """
   endCursor: String
 }
 
-"""An edge in a connection."""
+"""
+An edge in a connection.
+"""
 type TodoEdge {
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: Todo
 
-  """A cursor for use in pagination"""
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 }
 
 type Todo implements Node {
-  """The ID of an object"""
+  """
+  The ID of an object
+  """
   id: ID!
   text: String!
   complete: Boolean!
@@ -67,7 +107,9 @@ type Mutation {
   addTodo(input: AddTodoInput!): AddTodoPayload
   changeTodoStatus(input: ChangeTodoStatusInput!): ChangeTodoStatusPayload
   markAllTodos(input: MarkAllTodosInput!): MarkAllTodosPayload
-  removeCompletedTodos(input: RemoveCompletedTodosInput!): RemoveCompletedTodosPayload
+  removeCompletedTodos(
+    input: RemoveCompletedTodosInput!
+  ): RemoveCompletedTodosPayload
   removeTodo(input: RemoveTodoInput!): RemoveTodoPayload
   renameTodo(input: RenameTodoInput!): RenameTodoPayload
 }


### PR DESCRIPTION
Repro to demo a bug with the relay compiler
Bug:  Adding Unicode characters in comments ( 🐛), causes the Relay compiler to error

Looking at the graphql spec [notes](https://spec.graphql.org/October2021/#note-3e8b0), this feels like a bug.

#### How to repro
`yarn build` the todo example.

#### Error
```
[INFO] [default] compiling...
thread 'main' panicked at 'internal error: entered unreachable code', crates/graphql-syntax/src/lexer.rs:169:40
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
error Command failed with exit code 101.
```