### PR TITLE
Tweak Next 13 demo loading

### DIFF
--- a/issue-tracker-next-v13/app/MainViewClientComponent.tsx
+++ b/issue-tracker-next-v13/app/MainViewClientComponent.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import MainView from "src/components/MainView";
-import { Suspense } from "react";
 import { useRelayEnvironment } from "react-relay";
 import { SerializablePreloadedQuery } from "src/relay/loadSerializableQuery";
 import MainViewQueryNode, {
@@ -21,11 +20,7 @@ const MainViewClientComponent = (props: {
     props.preloadedQuery
   );
 
-  return (
-    <Suspense fallback="Loading...">
-      <MainView queryRef={queryRef} />
-    </Suspense>
-  );
+  return <MainView queryRef={queryRef} />;
 };
 
 export default MainViewClientComponent;

--- a/issue-tracker-next-v13/app/MainViewClientComponent.tsx
+++ b/issue-tracker-next-v13/app/MainViewClientComponent.tsx
@@ -2,12 +2,11 @@
 
 import MainView from "src/components/MainView";
 import { Suspense } from "react";
+import { useRelayEnvironment } from "react-relay";
 import { SerializablePreloadedQuery } from "src/relay/loadSerializableQuery";
 import MainViewQueryNode, {
   MainViewQuery,
 } from "__generated__/MainViewQuery.graphql";
-import { getCurrentEnvironment } from "src/relay/environment";
-import { RelayEnvironmentProvider } from "react-relay";
 import useSerializablePreloadedQuery from "src/relay/useSerializablePreloadedQuery";
 
 const MainViewClientComponent = (props: {
@@ -16,18 +15,16 @@ const MainViewClientComponent = (props: {
     MainViewQuery
   >;
 }) => {
-  const environment = getCurrentEnvironment();
+  const environment = useRelayEnvironment();
   const queryRef = useSerializablePreloadedQuery(
     environment,
     props.preloadedQuery
   );
 
   return (
-    <RelayEnvironmentProvider environment={environment}>
-      <Suspense fallback="Loading...">
-        <MainView queryRef={queryRef} />
-      </Suspense>
-    </RelayEnvironmentProvider>
+    <Suspense fallback="Loading...">
+      <MainView queryRef={queryRef} />
+    </Suspense>
   );
 };
 

--- a/issue-tracker-next-v13/app/issues/[id]/IssueViewClientComponent.tsx
+++ b/issue-tracker-next-v13/app/issues/[id]/IssueViewClientComponent.tsx
@@ -2,7 +2,6 @@
 
 import { useRelayEnvironment } from "react-relay";
 import Issue from "src/components/Issue";
-import { Suspense } from "react";
 import IssueQueryNode, { IssueQuery } from "__generated__/IssueQuery.graphql";
 import { SerializablePreloadedQuery } from "src/relay/loadSerializableQuery";
 import useSerializablePreloadedQuery from "src/relay/useSerializablePreloadedQuery";
@@ -16,11 +15,7 @@ const Root = (props: {
     props.preloadedQuery
   );
 
-  return (
-    <Suspense fallback="Loading...">
-      <Issue queryRef={queryRef} />
-    </Suspense>
-  );
+  return <Issue queryRef={queryRef} />;
 };
 
 export default Root;

--- a/issue-tracker-next-v13/app/issues/[id]/IssueViewClientComponent.tsx
+++ b/issue-tracker-next-v13/app/issues/[id]/IssueViewClientComponent.tsx
@@ -1,28 +1,25 @@
 "use client";
 
-import { RelayEnvironmentProvider } from "react-relay";
+import { useRelayEnvironment } from "react-relay";
 import Issue from "src/components/Issue";
 import { Suspense } from "react";
 import IssueQueryNode, { IssueQuery } from "__generated__/IssueQuery.graphql";
 import { SerializablePreloadedQuery } from "src/relay/loadSerializableQuery";
-import { getCurrentEnvironment } from "src/relay/environment";
 import useSerializablePreloadedQuery from "src/relay/useSerializablePreloadedQuery";
 
 const Root = (props: {
   preloadedQuery: SerializablePreloadedQuery<typeof IssueQueryNode, IssueQuery>;
 }) => {
-  const environment = getCurrentEnvironment();
+  const environment = useRelayEnvironment();
   const queryRef = useSerializablePreloadedQuery(
     environment,
     props.preloadedQuery
   );
 
   return (
-    <RelayEnvironmentProvider environment={environment}>
-      <Suspense fallback="Loading...">
-        <Issue queryRef={queryRef} />
-      </Suspense>
-    </RelayEnvironmentProvider>
+    <Suspense fallback="Loading...">
+      <Issue queryRef={queryRef} />
+    </Suspense>
   );
 };
 

--- a/issue-tracker-next-v13/app/layout.tsx
+++ b/issue-tracker-next-v13/app/layout.tsx
@@ -1,3 +1,7 @@
+"use client";
+
+import { RelayEnvironmentProvider } from "react-relay";
+import { getCurrentEnvironment } from "src/relay/environment";
 import "styles/globals.css";
 
 export default function RootLayout({
@@ -5,12 +9,16 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+  const environment = getCurrentEnvironment();
+
   return (
     <html>
       <head>
         <title>Github Issues: Relay</title>
       </head>
-      <body>{children}</body>
+      <RelayEnvironmentProvider environment={environment}>
+        <body>{children}</body>
+      </RelayEnvironmentProvider>
     </html>
   );
 }

--- a/issue-tracker-next-v13/app/loading.tsx
+++ b/issue-tracker-next-v13/app/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return "Loading...";
+}

--- a/issue-tracker-next-v13/app/loading.tsx
+++ b/issue-tracker-next-v13/app/loading.tsx
@@ -1,3 +1,3 @@
 export default function Loading() {
-  return "Loading...";
+  return "Loading (server side)...";
 }

--- a/issue-tracker-next-v13/src/components/Issue.tsx
+++ b/issue-tracker-next-v13/src/components/Issue.tsx
@@ -21,7 +21,7 @@ export default function Issue(props: { queryRef: PreloadedQuery<IssueQuery> }) {
   );
 
   return (
-    <Suspense fallback="Loading...">
+    <Suspense fallback="Loading (client side)...">
       <h1>{data.repository?.issue?.title}</h1>
       <p>{data.repository?.issue?.bodyText}</p>
       <p>Author: {data.repository?.issue?.author?.login}</p>

--- a/issue-tracker-next-v13/src/components/Issue.tsx
+++ b/issue-tracker-next-v13/src/components/Issue.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { graphql, PreloadedQuery, usePreloadedQuery } from "react-relay";
 import { IssueQuery } from "__generated__/IssueQuery.graphql";
 
@@ -20,10 +21,10 @@ export default function Issue(props: { queryRef: PreloadedQuery<IssueQuery> }) {
   );
 
   return (
-    <>
+    <Suspense fallback="Loading...">
       <h1>{data.repository?.issue?.title}</h1>
       <p>{data.repository?.issue?.bodyText}</p>
       <p>Author: {data.repository?.issue?.author?.login}</p>
-    </>
+    </Suspense>
   );
 }

--- a/issue-tracker-next-v13/src/components/Issues.tsx
+++ b/issue-tracker-next-v13/src/components/Issues.tsx
@@ -8,7 +8,7 @@ import styles from "styles/Issues.module.css";
 export default function Issues(props: {
   repository: IssuesFragment$key | null;
 }) {
-  const { data, loadNext, isLoadingNext } = usePaginationFragment<
+  const { data, loadNext, isLoadingNext, refetch } = usePaginationFragment<
     IssuesPaginationQuery,
     IssuesFragment$key
   >(
@@ -66,6 +66,15 @@ export default function Issues(props: {
       <li>
         <button onClick={loadMore} disabled={isLoadingNext}>
           {isLoadingNext ? "Loading..." : "Load More"}
+        </button>
+        <button
+          onClick={() =>
+            refetch({
+              count: 20,
+            })
+          }
+        >
+          Refetch with 20 items
         </button>
       </li>
     </ul>

--- a/issue-tracker-next-v13/src/components/MainView.tsx
+++ b/issue-tracker-next-v13/src/components/MainView.tsx
@@ -22,7 +22,7 @@ export default function MainView(props: {
   );
 
   return (
-    <Suspense fallback="Loading...">
+    <Suspense fallback="Loading (client side)...">
       <h1>
         {data.repository?.owner.login}/{data.repository?.name}
       </h1>

--- a/issue-tracker-next-v13/src/components/MainView.tsx
+++ b/issue-tracker-next-v13/src/components/MainView.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { graphql, PreloadedQuery, usePreloadedQuery } from "react-relay";
 import { MainViewQuery } from "__generated__/MainViewQuery.graphql";
 import Issues from "./Issues";
@@ -21,11 +22,11 @@ export default function MainView(props: {
   );
 
   return (
-    <div>
+    <Suspense fallback="Loading...">
       <h1>
         {data.repository?.owner.login}/{data.repository?.name}
       </h1>
       <Issues repository={data.repository} />
-    </div>
+    </Suspense>
   );
 }


### PR DESCRIPTION
I experimented with trying to make the demo work for my usecase. I needed to be able to server render full content while still being able to use Relay features after initial server load.

Much of the work had already been done (thank yoiu!), so it only took a few twaks in the end to get it working (but some time).

I have a few observations and questions:
- It looks to be doable without modifications to relay
- Using `usePreloadQuery` in `<Suspense>`seems to always cause hydration errors. Probably returns something other than the data on the first render. Although this is only true client-side. 
- Should `usePreloadQuery` be wrapped with `<Suspense>` in the first place?
- Is there a reason not to define `<RelayEnvironmentProvider>`in `layout.tsx`?

Other than that I think looking at the commit messages in this PR will explain the changes I've made. 

Some are just to demonstrate that thet changes are working, and I expect to remove them before this PR is considered for merging.