### PR TITLE
fix: Update LoadMoreCommentsButton.tsx component name

### DIFF
--- a/newsfeed/src/components/LoadMoreCommentsButton.tsx
+++ b/newsfeed/src/components/LoadMoreCommentsButton.tsx
@@ -5,7 +5,7 @@ type Props = {
   disabled?: boolean;
 };
 
-export default function Comment({
+export default function LoadMoreCommentsButton({
   onClick,
   disabled,
 }: Props): React.ReactElement {


### PR DESCRIPTION
According to the docs on https://relay.dev/docs/tutorial/connections-pagination/ the example used states the following code example:
```
{data.comments.pageInfo.hasNextPage && (
 	<LoadMoreCommentsButton onClick={onLoadMore} />
)}
```

Renamed component to match example.