### PR TITLE
Fix the name of react component OrganizationKind

### DIFF
--- a/newsfeed/src/components/OrganizationKind.tsx
+++ b/newsfeed/src/components/OrganizationKind.tsx
@@ -16,7 +16,7 @@ type Props = {
   kind: OrganizationKind;
 };
 
-export default function PosterBylineLocation({
+export default function OrganizationKind({
   kind,
 }: Props): React.ReactElement {
   return <div className="byline__detail">{label(kind)}</div>;


### PR DESCRIPTION
### Summary
The react component `OrganizationKind` was named `PosterBylineLocation`. It should be `OrganizationKind`.

### Test Plan
Follows the "Newsfeed" tutorial "Queries for Interactions" section. The organization name is shown when mouse hover the poster.

Fixing issue #286.