### PR TITLE
Next.js App Router example: make root layout a server component

### DIFF
--- a/issue-tracker-next-v13/app/layout.tsx
+++ b/issue-tracker-next-v13/app/layout.tsx
@@ -1,9 +1,6 @@
-"use client";
-
-import { RelayEnvironmentProvider } from "react-relay";
-import { getCurrentEnvironment } from "src/relay/environment";
 import "styles/globals.css";
 
+import EnvironmentProvider from "src/relay/EnvironmentProvider";
 import styles from "styles/layout.module.css";
 
 export default function RootLayout({
@@ -11,16 +8,14 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const environment = getCurrentEnvironment();
-
   return (
     <html>
       <head>
         <title>Github Issues: Relay</title>
       </head>
-      <RelayEnvironmentProvider environment={environment}>
-        <body className={styles.layout}>{children}</body>
-      </RelayEnvironmentProvider>
+      <body className={styles.layout}>
+        <EnvironmentProvider>{children}</EnvironmentProvider>
+      </body>
     </html>
   );
 }

--- a/issue-tracker-next-v13/src/relay/EnvironmentProvider.tsx
+++ b/issue-tracker-next-v13/src/relay/EnvironmentProvider.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { RelayEnvironmentProvider } from "react-relay";
+
+import { getCurrentEnvironment } from "./environment";
+
+export default function EnvironmentProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const environment = getCurrentEnvironment();
+  return (
+    <RelayEnvironmentProvider environment={environment}>
+      {children}
+    </RelayEnvironmentProvider>
+  );
+}


### PR DESCRIPTION
This change makes RootLayout a server component by moving `EnvironmentProvider` initialization into a separate client component