### PR TITLE
Update StoryCommentsSection.tsx to accurately reflect Relay tutorial

### DIFF
--- a/newsfeed/src/components/StoryCommentsSection.tsx
+++ b/newsfeed/src/components/StoryCommentsSection.tsx
@@ -3,8 +3,7 @@ import { graphql } from "relay-runtime";
 import { useFragment } from "react-relay";
 import type { StoryCommentsSectionFragment$key } from "./__generated__/StoryCommentsSectionFragment.graphql";
 import Comment from "./Comment";
-
-const { useState, useTransition } = React;
+import LoadMoreCommentsButton from "./LoadMoreCommentsButton";
 
 export type Props = {
   story: StoryCommentsSectionFragment$key;
@@ -12,15 +11,14 @@ export type Props = {
 
 const StoryCommentsSectionFragment = graphql`
   fragment StoryCommentsSectionFragment on Story {
-    comments(first: 1) {
-      pageInfo {
-        startCursor
-      }
+    comments(first: 3) {
       edges {
         node {
-          id
           ...CommentFragment
         }
+      }
+      pageInfo {
+        hasNextPage
       }
     }
   }
@@ -28,11 +26,15 @@ const StoryCommentsSectionFragment = graphql`
 
 export default function StoryCommentsSection({ story }: Props) {
   const data = useFragment(StoryCommentsSectionFragment, story);
+  const onLoadMore = () => {/* TODO */};
   return (
-    <div>
-      {data.comments.edges.map((edge) => (
-        <Comment key={edge.node.id} comment={edge.node} />
-      ))}
-    </div>
+    <>
+      {data.comments.edges.map(commentEdge =>
+        <Comment comment={commentEdge.node} />
+      )}
+      {data.comments.pageInfo.hasNextPage && (
+        <LoadMoreCommentsButton onClick={onLoadMore} />
+      )}
+    </>
   );
 }


### PR DESCRIPTION
Following the steps in the [Connections & Pagination](https://relay.dev/docs/next/tutorial/connections-pagination/#implementing-load-more-comments) part of the Relay Tutorial is clearly states that: 

> At this point, you should see up to three comments on each story. Some stories have more than three comments, and these will show a "Load more" button, although it isn't hooked up yet.

But the example only loads 1 comments, and there is no "Load more" button present. The tutorial assumes that this code is already present and that is confusing to the reader.

In this PR I've updated `StoryCommentsSection.tsx` to reflect the code examples & instructions in the tutorial.

Thanks!