### PR TITLE
Fix the spinner for the newsfeed example used in the Relay tutorial

### DIFF
--- a/newsfeed/src/components/App.tsx
+++ b/newsfeed/src/components/App.tsx
@@ -6,7 +6,13 @@ import LoadingSpinner from "./LoadingSpinner";
 export default function App(): React.ReactElement {
   return (
     <RelayEnvironment>
-      <React.Suspense fallback={<LoadingSpinner />}>
+      <React.Suspense
+        fallback={
+          <div className="app-loading-spinner">
+            <LoadingSpinner />
+          </div>
+        }
+      >
         <div className="app">
           <Newsfeed />
         </div>

--- a/newsfeed/src/style.css
+++ b/newsfeed/src/style.css
@@ -284,12 +284,17 @@ body {
   box-shadow: 0 2px 2px rgba(0, 0, 0, 0.2);
 }
 
-/* Spinner */
-
-.loading-spinner-wrapper {
+.app-loading-spinner {
   position: absolute;
   top: 50vh;
   left: calc(50% - 40px);
+}
+
+/* Spinner */
+
+.loading-spinner-wrapper {
+  display: flex;
+  justify-content: center;
 }
 
 .loading-spinner {


### PR DESCRIPTION
This commit is to fix the spinner used in the Relay tutorial example. The spinner is being used throughout the app, but has a `position: absolute` to try and center is when the main app is loading. This breaks the spinner for the hovercard and other places it's used. I updated the spinner to just be horizontally centered without a `position: absolute` and wrapped it for the main app spinner.
Before:
<img width="797" alt="Relay tutorial spinner bug" src="https://github.com/user-attachments/assets/3b2cdda4-2307-40c7-b343-58a39c67927e" />
After:
<img width="849" alt="Relay tutorial spinner fixed" src="https://github.com/user-attachments/assets/5270fea3-56b5-44ae-be3d-035902b8f2c3" />
