### PR TITLE
Update newsfeed connection example to match the tutorial

### DIFF
--- a/newsfeed/src/components/StoryCommentsSection.tsx
+++ b/newsfeed/src/components/StoryCommentsSection.tsx
@@ -3,8 +3,7 @@ import { graphql } from "relay-runtime";
 import { useFragment } from "react-relay";
 import type { StoryCommentsSectionFragment$key } from "./__generated__/StoryCommentsSectionFragment.graphql";
 import Comment from "./Comment";
-
-const { useState, useTransition } = React;
+import LoadMoreCommentsButton from "./LoadMoreCommentsButton";
 
 export type Props = {
   story: StoryCommentsSectionFragment$key;
@@ -12,15 +11,15 @@ export type Props = {
 
 const StoryCommentsSectionFragment = graphql`
   fragment StoryCommentsSectionFragment on Story {
-    comments(first: 1) {
-      pageInfo {
-        startCursor
-      }
+    comments(first: 3) {
       edges {
         node {
           id
           ...CommentFragment
         }
+      }
+      pageInfo {
+        hasNextPage
       }
     }
   }
@@ -28,11 +27,17 @@ const StoryCommentsSectionFragment = graphql`
 
 export default function StoryCommentsSection({ story }: Props) {
   const data = useFragment(StoryCommentsSectionFragment, story);
+  const onLoadMore = () => {
+    /* TODO */
+  };
   return (
     <div>
       {data.comments.edges.map((edge) => (
         <Comment key={edge.node.id} comment={edge.node} />
       ))}
+      {data.comments.pageInfo.hasNextPage && (
+        <LoadMoreCommentsButton onClick={onLoadMore} />
+      )}
     </div>
   );
 }

--- a/newsfeed/src/components/__generated__/StoryCommentsSectionFragment.graphql.ts
+++ b/newsfeed/src/components/__generated__/StoryCommentsSectionFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9084679bca54b3fb32d232a9ecf484ad>>
+ * @generated SignedSource<<90e45a4f0961bbf83f009aafa324925c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -19,7 +19,7 @@ export type StoryCommentsSectionFragment$data = {
       } | null;
     } | null> | null;
     readonly pageInfo: {
-      readonly startCursor: string | null;
+      readonly hasNextPage: boolean | null;
     } | null;
   } | null;
   readonly " $fragmentType": "StoryCommentsSectionFragment";
@@ -41,7 +41,7 @@ const node: ReaderFragment = {
         {
           "kind": "Literal",
           "name": "first",
-          "value": 1
+          "value": 3
         }
       ],
       "concreteType": "CommentsConnection",
@@ -49,24 +49,6 @@ const node: ReaderFragment = {
       "name": "comments",
       "plural": false,
       "selections": [
-        {
-          "alias": null,
-          "args": null,
-          "concreteType": "PageInfo",
-          "kind": "LinkedField",
-          "name": "pageInfo",
-          "plural": false,
-          "selections": [
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "startCursor",
-              "storageKey": null
-            }
-          ],
-          "storageKey": null
-        },
         {
           "alias": null,
           "args": null,
@@ -100,15 +82,33 @@ const node: ReaderFragment = {
             }
           ],
           "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "PageInfo",
+          "kind": "LinkedField",
+          "name": "pageInfo",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "hasNextPage",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
         }
       ],
-      "storageKey": "comments(first:1)"
+      "storageKey": "comments(first:3)"
     }
   ],
   "type": "Story",
   "abstractKey": null
 };
 
-(node as any).hash = "38376c4754335036300071e38e1aa708";
+(node as any).hash = "623aea3d09348623d170898c472f9531";
 
 export default node;


### PR DESCRIPTION
The tutorial example in https://relay.dev/docs/tutorial/connections-pagination/#implementing-load-more-comments doesn't match the code in the `StoryCommentsSection` by default. This just updates the component to match the tutorial code.