### PR TITLE
Upgrade data-driven-dependencies to Relay v21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,19 +13,19 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [18.x, 20.x, 22.x]
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install watchman
         run: |
           mkdir watchman
           cd watchman
-          curl -L -O 'https://github.com/facebook/watchman/releases/download/v2021.05.24.00/watchman-v2021.05.24.00-linux.zip'
-          unzip watchman-v2021.05.24.00-linux.zip
-          cd watchman-v2021.05.24.00-linux
+          curl -L -O 'https://github.com/facebook/watchman/releases/download/v2026.05.11.00/watchman-v2026.05.11.00-linux.zip'
+          unzip watchman-v2026.05.11.00-linux.zip
+          cd watchman-v2026.05.11.00-linux
           sudo mkdir -p /usr/local/{bin,lib} /usr/local/var/run/watchman
           sudo cp bin/* /usr/local/bin
           sudo cp lib/* /usr/local/lib

--- a/data-driven-dependencies/lib/blogPosts.mjs
+++ b/data-driven-dependencies/lib/blogPosts.mjs
@@ -38,10 +38,7 @@ function generateBlogPost() {
 
 export function findBlogPost(id) {
   const post = blogPosts.find((post) => post.id == id);
-  return blogPosts.find((post) => post.id == id);
-  return post ?  ({
-    content: post
-  }) : null;
+  return post ? {content: post} : null;
 }
 
 // Fake implementation of the `allBlogPosts` connection

--- a/data-driven-dependencies/lib/graphql.mjs
+++ b/data-driven-dependencies/lib/graphql.mjs
@@ -74,6 +74,9 @@ const FancyBlogPostType = new GraphQLObjectType({
 const BlogPostUnion = new GraphQLUnionType({
   name: 'BlogPostUnion',
   types: [BlogPostType, FancyBlogPostType],
+  resolveType(obj) {
+    return obj.__typename === 'FancyBlogPost' ? 'FancyBlogPost' : 'BlogPost';
+  },
 });
 
 const Post = new GraphQLObjectType({

--- a/data-driven-dependencies/package.json
+++ b/data-driven-dependencies/package.json
@@ -19,14 +19,14 @@
     "prettier": "^2.6.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "relay-runtime": "^14.0.0",
-    "react-relay": "^14.0.0"
+    "react-relay": "^21.0.0",
+    "relay-runtime": "^21.0.0"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.4",
     "concurrently": "^7.0.0",
     "postcss": "^8.4.12",
-    "relay-compiler": "^14.0.0",
+    "relay-compiler": "^21.0.0",
     "tailwindcss": "^3.0.23"
   },
   "prettier": {

--- a/data-driven-dependencies/relay.config.json
+++ b/data-driven-dependencies/relay.config.json
@@ -4,6 +4,7 @@
   "artifactDirectory": "./__generated__",
   "excludes": ["**/.next/**", "**/node_modules/**", "**/schema/**"],
   "language": "javascript",
+  "eagerEsModules": false,
   "persistConfig": {
     "file": "./queryMap.json"
   }

--- a/data-driven-dependencies/yarn.lock
+++ b/data-driven-dependencies/yarn.lock
@@ -23,12 +23,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/runtime@^7.0.0":
-  version "7.17.8"
-  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.8.tgz"
-  integrity sha512-dQpEpK0O9o6lj6oPu0gRDbbnk+4LeHlNcBpspf6Olzt3GIX4P1lWF1gS+pHLDFlaJvbR6q7jCfQ08zA4QJBnmA==
-  dependencies:
-    regenerator-runtime "^0.13.4"
+"@babel/runtime@^7.25.0":
+  version "7.29.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.2.tgz#9a6e2d05f4b6692e1801cd4fb176ad823930ed5e"
+  integrity sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==
 
 "@next/env@12.1.4":
   version "12.1.4"
@@ -780,16 +778,16 @@ react-dom@^18.0.0:
     loose-envify "^1.1.0"
     scheduler "^0.21.0"
 
-react-relay@^14.0.0:
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/react-relay/-/react-relay-14.0.0.tgz#c9f9b8912bcef589782bea6a382548d55d20d522"
-  integrity sha512-zqT8ZS1lq24p1R8nW5Vi03oB1Ix8aYJxyuSl4bB8XDjSNL0kFuAdN8R5LrundUd3vuKjkV1UBfb1xuuoRroUhA==
+react-relay@^21.0.0:
+  version "21.0.0"
+  resolved "https://registry.yarnpkg.com/react-relay/-/react-relay-21.0.0.tgz#dab50d9a10f6e610148c01ea7941723717993c62"
+  integrity sha512-lGnL9lmDVIHX/mF4qFGC9DXIm26RqMDNI1lBoxrAYXtk7i1Llo1NB3aC0Rf7fRVq6MY3ycBC8eKdYTOmeLloaA==
   dependencies:
-    "@babel/runtime" "^7.0.0"
+    "@babel/runtime" "^7.25.0"
     fbjs "^3.0.2"
     invariant "^2.2.4"
     nullthrows "^1.1.1"
-    relay-runtime "14.0.0"
+    relay-runtime "21.0.0"
 
 react@^18.0.0:
   version "18.0.0"
@@ -805,22 +803,17 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
-regenerator-runtime@^0.13.4:
-  version "0.13.9"
-  resolved "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz"
-  integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==
+relay-compiler@^21.0.0:
+  version "21.0.0"
+  resolved "https://registry.yarnpkg.com/relay-compiler/-/relay-compiler-21.0.0.tgz#43e86ea95f51e441754efe1c5fe622688c35200a"
+  integrity sha512-ni8U67uybKAE1Aeh+tHw7Dmoeuvgm+UmEohJH8bAcoCnMkFX5Nj/6kGR/KyxcOSxdcXIkApAzurbXX+lUda6Wg==
 
-relay-compiler@^14.0.0:
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/relay-compiler/-/relay-compiler-14.0.0.tgz#03ab000c246c7c46a26b77584b345621155a770e"
-  integrity sha512-1h4lwvHg5efhivqpMfG6SS4cGoCJH3BsRelihwD+GNiylBnLKArSE6zyW7LfEwSpuDfJ+l6rrRfSL8IVZwOZ0g==
-
-relay-runtime@14.0.0, relay-runtime@^14.0.0:
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/relay-runtime/-/relay-runtime-14.0.0.tgz#e2fa40d73569d2ba5810c773fb85ac872b08b5d0"
-  integrity sha512-Rnf6EgCl3QY85il/gTEh6GHAR9hoRkjYWgMR2Y3Afugb8qLR0vL6m/GBYqol8W3L8B+XqZ2U04/g624DRpEqAw==
+relay-runtime@21.0.0, relay-runtime@^21.0.0:
+  version "21.0.0"
+  resolved "https://registry.yarnpkg.com/relay-runtime/-/relay-runtime-21.0.0.tgz#2c9aaceb3464d39292b51fd4ffd08771082f11c6"
+  integrity sha512-CEKncRm8BOPT3IlymyfTVzQ8jNDgw0KrCAwel0QMG1R+ESpeMVTrWJzTGCjrzzT5MT2AEWZdCkClZ0JtXSKmUw==
   dependencies:
-    "@babel/runtime" "^7.0.0"
+    "@babel/runtime" "^7.25.0"
     fbjs "^3.0.2"
     invariant "^2.2.4"
 


### PR DESCRIPTION
## Summary
- Upgrade react-relay, relay-runtime, and relay-compiler from v14 to v21
- Add `resolveType` to `BlogPostUnion` (graphql-js 16 requires returning type name strings, not type objects)
- Fix `findBlogPost` bug: duplicate return statement caused the correct `{content: post}` return to be dead code
- Set `eagerEsModules: false` in relay config so the compiler generates CommonJS artifacts compatible with the Next.js SWC relay transform

## Test plan
- [ ] Run `yarn dev` in `data-driven-dependencies/` and verify the index page loads blog posts
- [ ] Verify clicking a blog post navigates to the detail page without errors
- [ ] Verify "Load More" pagination works
- [ ] Verify both `BlogPost` and `FancyBlogPost` types render correctly via data-driven dependencies