### PR TITLE
Fix CI: update watchman, Node.js, and actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,19 +13,19 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [18.x, 20.x, 22.x]
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install watchman
         run: |
           mkdir watchman
           cd watchman
-          curl -L -O 'https://github.com/facebook/watchman/releases/download/v2021.05.24.00/watchman-v2021.05.24.00-linux.zip'
-          unzip watchman-v2021.05.24.00-linux.zip
-          cd watchman-v2021.05.24.00-linux
+          curl -L -O 'https://github.com/facebook/watchman/releases/download/v2026.05.11.00/watchman-v2026.05.11.00-linux.zip'
+          unzip watchman-v2026.05.11.00-linux.zip
+          cd watchman-v2026.05.11.00-linux
           sudo mkdir -p /usr/local/{bin,lib} /usr/local/var/run/watchman
           sudo cp bin/* /usr/local/bin
           sudo cp lib/* /usr/local/lib


### PR DESCRIPTION
## Summary
- Update watchman from v2021.05.24.00 to v2026.05.11.00 (old binary requires `libcrypto.so.1.1` which is no longer on current Ubuntu runners)
- Update Node.js test matrix from 12/14/16 (all EOL) to 18/20/22
- Update actions/checkout and actions/setup-node from v1 to v4

## Test plan
- [x] CI passes on all three Node.js versions (verified on #337)