### PR TITLE
Upgrade issue-tracker example to Relay v21

### DIFF
--- a/issue-tracker/package.json
+++ b/issue-tracker/package.json
@@ -9,14 +9,14 @@
     "react": "0.0.0-experimental-f42431abe",
     "react-dom": "0.0.0-experimental-f42431abe",
     "react-markdown": "^4.2.2",
-    "react-relay": "^14.0.0",
+    "react-relay": "^21.0.0",
     "react-router": "^5.1.2",
     "react-router-config": "^5.1.1",
     "react-scripts": "3.2.0",
-    "relay-runtime": "^14.0.0"
+    "relay-runtime": "^21.0.0"
   },
   "scripts": {
-    "start": "yarn run relay; concurrently --kill-others --names \"react-scripts,relay\" \"react-scripts start\" \"yarn run relay --watch\"",
+    "start": "NODE_OPTIONS=--openssl-legacy-provider yarn run relay; concurrently --kill-others --names \"react-scripts,relay\" \"NODE_OPTIONS=--openssl-legacy-provider react-scripts start\" \"yarn run relay --watch\"",
     "build": "yarn run relay && react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
@@ -58,7 +58,7 @@
     "get-graphql-schema": "^2.1.2",
     "graphql": "^15.6.1",
     "prettier": "^1.18.2",
-    "relay-compiler": "^14.0.0"
+    "relay-compiler": "^21.0.0"
   },
   "husky": {
     "hooks": {

--- a/issue-tracker/src/IssueDetailRoot.js
+++ b/issue-tracker/src/IssueDetailRoot.js
@@ -28,8 +28,8 @@ export default function IssueDetailRoot(props) {
             body
             closed
             url
-            ...IssueDetailComments_issue
-            ...IssueActions_issue
+            ...IssueDetailComments_issue @alias
+            ...IssueActions_issue @alias
           }
         }
       }
@@ -66,8 +66,12 @@ export default function IssueDetailRoot(props) {
           />
         </div>
       </div>
-      <IssueDetailComments issue={issue} />
-      <IssueActions issue={issue} />
+      {issue.IssueDetailComments_issue != null && (
+        <IssueDetailComments issue={issue.IssueDetailComments_issue} />
+      )}
+      {issue.IssueActions_issue != null && (
+        <IssueActions issue={issue.IssueActions_issue} />
+      )}
     </div>
   );
 }

--- a/issue-tracker/src/RelayEnvironment.js
+++ b/issue-tracker/src/RelayEnvironment.js
@@ -1,4 +1,13 @@
-import { Environment, Network, RecordSource, Store } from 'relay-runtime';
+import {
+  Environment,
+  Network,
+  RecordSource,
+  Store,
+  RelayFeatureFlags,
+} from 'relay-runtime';
+
+// Activity compatibility requries a newer version of React.
+RelayFeatureFlags.ENABLE_ACTIVITY_COMPATIBILITY = false;
 
 /**
  * Relay requires developers to configure a "fetch" function that tells Relay how to load

--- a/issue-tracker/src/__generated__/HomeRootIssuesQuery.graphql.js
+++ b/issue-tracker/src/__generated__/HomeRootIssuesQuery.graphql.js
@@ -1,8 +1,7 @@
 /**
- * @generated SignedSource<<44e5146557bc357ed7c0744a0ebfb032>>
+ * @generated SignedSource<<5746caa056f866a64631f5ca1186aaf8>>
  * @flow
  * @lightSyntaxTransform
- * @nogrep
  */
 
 /* eslint-disable */
@@ -11,7 +10,7 @@
 
 /*::
 import type { ConcreteRequest, Query } from 'relay-runtime';
-type Issues_repository$fragmentType = any;
+import type { Issues_repository$fragmentType } from "./Issues_repository.graphql";
 export type HomeRootIssuesQuery$variables = {|
   name: string,
   owner: string,
@@ -72,8 +71,8 @@ v4 = {
 return {
   "fragment": {
     "argumentDefinitions": [
-      (v0/*: any*/),
-      (v1/*: any*/)
+      (v0/*:: as any*/),
+      (v1/*:: as any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -81,7 +80,7 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v2/*: any*/),
+        "args": (v2/*:: as any*/),
         "concreteType": "Repository",
         "kind": "LinkedField",
         "name": "repository",
@@ -102,15 +101,15 @@ return {
   "kind": "Request",
   "operation": {
     "argumentDefinitions": [
-      (v1/*: any*/),
-      (v0/*: any*/)
+      (v1/*:: as any*/),
+      (v0/*:: as any*/)
     ],
     "kind": "Operation",
     "name": "HomeRootIssuesQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v2/*: any*/),
+        "args": (v2/*:: as any*/),
         "concreteType": "Repository",
         "kind": "LinkedField",
         "name": "repository",
@@ -118,7 +117,7 @@ return {
         "selections": [
           {
             "alias": null,
-            "args": (v3/*: any*/),
+            "args": (v3/*:: as any*/),
             "concreteType": "IssueConnection",
             "kind": "LinkedField",
             "name": "issues",
@@ -140,7 +139,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v4/*: any*/),
+                      (v4/*:: as any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -210,7 +209,7 @@ return {
           },
           {
             "alias": null,
-            "args": (v3/*: any*/),
+            "args": (v3/*:: as any*/),
             "filters": [
               "states"
             ],
@@ -219,7 +218,7 @@ return {
             "kind": "LinkedHandle",
             "name": "issues"
           },
-          (v4/*: any*/)
+          (v4/*:: as any*/)
         ],
         "storageKey": null
       }
@@ -236,9 +235,9 @@ return {
 };
 })();
 
-(node/*: any*/).hash = "123ee85bfef2bb303a99a7320127372f";
+(node/*:: as any*/).hash = "123ee85bfef2bb303a99a7320127372f";
 
-module.exports = ((node/*: any*/)/*: Query<
+export default ((node/*:: as any*/)/*:: as Query<
   HomeRootIssuesQuery$variables,
   HomeRootIssuesQuery$data,
 >*/);

--- a/issue-tracker/src/__generated__/IssueActionsAddCommentMutation.graphql.js
+++ b/issue-tracker/src/__generated__/IssueActionsAddCommentMutation.graphql.js
@@ -1,8 +1,7 @@
 /**
- * @generated SignedSource<<5c523c009dcef4ac8a792bcb6f370cb1>>
+ * @generated SignedSource<<c6324cfc052517896637123d19dcda6a>>
  * @flow
  * @lightSyntaxTransform
- * @nogrep
  */
 
 /* eslint-disable */
@@ -66,7 +65,7 @@ v2 = {
   "storageKey": null
 },
 v3 = [
-  (v2/*: any*/)
+  (v2/*:: as any*/)
 ],
 v4 = {
   "alias": null,
@@ -110,14 +109,14 @@ v8 = {
 };
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0/*:: as any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "IssueActionsAddCommentMutation",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v1/*:: as any*/),
         "concreteType": "AddCommentPayload",
         "kind": "LinkedField",
         "name": "addComment",
@@ -130,7 +129,7 @@ return {
             "kind": "LinkedField",
             "name": "subject",
             "plural": false,
-            "selections": (v3/*: any*/),
+            "selections": (v3/*:: as any*/),
             "storageKey": null
           },
           {
@@ -149,7 +148,7 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  (v2/*: any*/),
+                  (v2/*:: as any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -158,16 +157,16 @@ return {
                     "name": "author",
                     "plural": false,
                     "selections": [
-                      (v4/*: any*/),
-                      (v5/*: any*/)
+                      (v4/*:: as any*/),
+                      (v5/*:: as any*/)
                     ],
                     "storageKey": null
                   },
-                  (v6/*: any*/)
+                  (v6/*:: as any*/)
                 ],
                 "storageKey": null
               },
-              (v7/*: any*/)
+              (v7/*:: as any*/)
             ],
             "storageKey": null
           }
@@ -180,13 +179,13 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0/*:: as any*/),
     "kind": "Operation",
     "name": "IssueActionsAddCommentMutation",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v1/*:: as any*/),
         "concreteType": "AddCommentPayload",
         "kind": "LinkedField",
         "name": "addComment",
@@ -200,8 +199,8 @@ return {
             "name": "subject",
             "plural": false,
             "selections": [
-              (v8/*: any*/),
-              (v2/*: any*/)
+              (v8/*:: as any*/),
+              (v2/*:: as any*/)
             ],
             "storageKey": null
           },
@@ -221,7 +220,7 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  (v2/*: any*/),
+                  (v2/*:: as any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -230,23 +229,23 @@ return {
                     "name": "author",
                     "plural": false,
                     "selections": [
-                      (v8/*: any*/),
-                      (v4/*: any*/),
-                      (v5/*: any*/),
+                      (v8/*:: as any*/),
+                      (v4/*:: as any*/),
+                      (v5/*:: as any*/),
                       {
                         "kind": "InlineFragment",
-                        "selections": (v3/*: any*/),
+                        "selections": (v3/*:: as any*/),
                         "type": "Node",
                         "abstractKey": "__isNode"
                       }
                     ],
                     "storageKey": null
                   },
-                  (v6/*: any*/)
+                  (v6/*:: as any*/)
                 ],
                 "storageKey": null
               },
-              (v7/*: any*/)
+              (v7/*:: as any*/)
             ],
             "storageKey": null
           }
@@ -266,9 +265,9 @@ return {
 };
 })();
 
-(node/*: any*/).hash = "f777dc7f1873d5cdab111f485ef8f404";
+(node/*:: as any*/).hash = "f777dc7f1873d5cdab111f485ef8f404";
 
-module.exports = ((node/*: any*/)/*: Mutation<
+export default ((node/*:: as any*/)/*:: as Mutation<
   IssueActionsAddCommentMutation$variables,
   IssueActionsAddCommentMutation$data,
 >*/);

--- a/issue-tracker/src/__generated__/IssueActionsCloseIssueMutation.graphql.js
+++ b/issue-tracker/src/__generated__/IssueActionsCloseIssueMutation.graphql.js
@@ -1,8 +1,7 @@
 /**
- * @generated SignedSource<<89c0b657d79847ddc80199034fe814cd>>
+ * @generated SignedSource<<dc1d96c4589535acb03bd0d14469ae33>>
  * @flow
  * @lightSyntaxTransform
- * @nogrep
  */
 
 /* eslint-disable */
@@ -55,14 +54,14 @@ v2 = {
 };
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0/*:: as any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "IssueActionsCloseIssueMutation",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v1/*:: as any*/),
         "concreteType": "CloseIssuePayload",
         "kind": "LinkedField",
         "name": "closeIssue",
@@ -76,7 +75,7 @@ return {
             "name": "issue",
             "plural": false,
             "selections": [
-              (v2/*: any*/)
+              (v2/*:: as any*/)
             ],
             "storageKey": null
           }
@@ -89,13 +88,13 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0/*:: as any*/),
     "kind": "Operation",
     "name": "IssueActionsCloseIssueMutation",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v1/*:: as any*/),
         "concreteType": "CloseIssuePayload",
         "kind": "LinkedField",
         "name": "closeIssue",
@@ -109,7 +108,7 @@ return {
             "name": "issue",
             "plural": false,
             "selections": [
-              (v2/*: any*/),
+              (v2/*:: as any*/),
               {
                 "alias": null,
                 "args": null,
@@ -136,9 +135,9 @@ return {
 };
 })();
 
-(node/*: any*/).hash = "51e445c25b3f4b3c48c3d6ca6c5f2f5a";
+(node/*:: as any*/).hash = "51e445c25b3f4b3c48c3d6ca6c5f2f5a";
 
-module.exports = ((node/*: any*/)/*: Mutation<
+export default ((node/*:: as any*/)/*:: as Mutation<
   IssueActionsCloseIssueMutation$variables,
   IssueActionsCloseIssueMutation$data,
 >*/);

--- a/issue-tracker/src/__generated__/IssueActionsReopenIssueMutation.graphql.js
+++ b/issue-tracker/src/__generated__/IssueActionsReopenIssueMutation.graphql.js
@@ -1,8 +1,7 @@
 /**
- * @generated SignedSource<<41f94f17b07fc0d5503758191a569d1c>>
+ * @generated SignedSource<<c0c99b0ebc9d9168959db231a2a94c7e>>
  * @flow
  * @lightSyntaxTransform
- * @nogrep
  */
 
 /* eslint-disable */
@@ -55,14 +54,14 @@ v2 = {
 };
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0/*:: as any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "IssueActionsReopenIssueMutation",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v1/*:: as any*/),
         "concreteType": "ReopenIssuePayload",
         "kind": "LinkedField",
         "name": "reopenIssue",
@@ -76,7 +75,7 @@ return {
             "name": "issue",
             "plural": false,
             "selections": [
-              (v2/*: any*/)
+              (v2/*:: as any*/)
             ],
             "storageKey": null
           }
@@ -89,13 +88,13 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0/*:: as any*/),
     "kind": "Operation",
     "name": "IssueActionsReopenIssueMutation",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v1/*:: as any*/),
         "concreteType": "ReopenIssuePayload",
         "kind": "LinkedField",
         "name": "reopenIssue",
@@ -109,7 +108,7 @@ return {
             "name": "issue",
             "plural": false,
             "selections": [
-              (v2/*: any*/),
+              (v2/*:: as any*/),
               {
                 "alias": null,
                 "args": null,
@@ -136,9 +135,9 @@ return {
 };
 })();
 
-(node/*: any*/).hash = "6dbb9d9a672b1703eb0983667e9638db";
+(node/*:: as any*/).hash = "6dbb9d9a672b1703eb0983667e9638db";
 
-module.exports = ((node/*: any*/)/*: Mutation<
+export default ((node/*:: as any*/)/*:: as Mutation<
   IssueActionsReopenIssueMutation$variables,
   IssueActionsReopenIssueMutation$data,
 >*/);

--- a/issue-tracker/src/__generated__/IssueActions_issue.graphql.js
+++ b/issue-tracker/src/__generated__/IssueActions_issue.graphql.js
@@ -1,8 +1,7 @@
 /**
- * @generated SignedSource<<9e84403d946ea2fa1962a6245812b55f>>
+ * @generated SignedSource<<58c75f4977df8b84e670e3d1be45e4d3>>
  * @flow
  * @lightSyntaxTransform
- * @nogrep
  */
 
 /* eslint-disable */
@@ -50,9 +49,9 @@ var node/*: ReaderFragment*/ = {
   "abstractKey": null
 };
 
-(node/*: any*/).hash = "12c79d27df99eb9656621cead33c9d08";
+(node/*:: as any*/).hash = "12c79d27df99eb9656621cead33c9d08";
 
-module.exports = ((node/*: any*/)/*: Fragment<
+export default ((node/*:: as any*/)/*:: as Fragment<
   IssueActions_issue$fragmentType,
   IssueActions_issue$data,
 >*/);

--- a/issue-tracker/src/__generated__/IssueDetailCommentsQuery.graphql.js
+++ b/issue-tracker/src/__generated__/IssueDetailCommentsQuery.graphql.js
@@ -1,8 +1,7 @@
 /**
- * @generated SignedSource<<9f5939c4cc30c45ca681cbec229b6023>>
+ * @generated SignedSource<<a974aeba02941c932328485599795388>>
  * @flow
  * @lightSyntaxTransform
- * @nogrep
  */
 
 /* eslint-disable */
@@ -12,7 +11,7 @@
 /*::
 import type { ConcreteRequest, Query } from 'relay-runtime';
 import type { FragmentType } from "relay-runtime";
-type IssueDetailComments_issue$fragmentType = any;
+import type { IssueDetailComments_issue$fragmentType } from "./IssueDetailComments_issue.graphql";
 export type IssueDetailCommentsQuery$variables = {|
   count?: ?number,
   cursor?: ?string,
@@ -82,14 +81,14 @@ v4 = [
 ];
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0/*:: as any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "IssueDetailCommentsQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v1/*:: as any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
@@ -120,26 +119,26 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0/*:: as any*/),
     "kind": "Operation",
     "name": "IssueDetailCommentsQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v1/*:: as any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v2/*: any*/),
-          (v3/*: any*/),
+          (v2/*:: as any*/),
+          (v3/*:: as any*/),
           {
             "kind": "InlineFragment",
             "selections": [
               {
                 "alias": null,
-                "args": (v4/*: any*/),
+                "args": (v4/*:: as any*/),
                 "concreteType": "IssueCommentConnection",
                 "kind": "LinkedField",
                 "name": "comments",
@@ -161,7 +160,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v3/*: any*/),
+                          (v3/*:: as any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -170,7 +169,7 @@ return {
                             "name": "author",
                             "plural": false,
                             "selections": [
-                              (v2/*: any*/),
+                              (v2/*:: as any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -188,7 +187,7 @@ return {
                               {
                                 "kind": "InlineFragment",
                                 "selections": [
-                                  (v3/*: any*/)
+                                  (v3/*:: as any*/)
                                 ],
                                 "type": "Node",
                                 "abstractKey": "__isNode"
@@ -203,7 +202,7 @@ return {
                             "name": "body",
                             "storageKey": null
                           },
-                          (v2/*: any*/)
+                          (v2/*:: as any*/)
                         ],
                         "storageKey": null
                       },
@@ -259,7 +258,7 @@ return {
               },
               {
                 "alias": null,
-                "args": (v4/*: any*/),
+                "args": (v4/*:: as any*/),
                 "filters": null,
                 "handle": "connection",
                 "key": "IssueDetailComments_comments",
@@ -286,9 +285,9 @@ return {
 };
 })();
 
-(node/*: any*/).hash = "674952f209c2653f27a5fad5539df511";
+(node/*:: as any*/).hash = "674952f209c2653f27a5fad5539df511";
 
-module.exports = ((node/*: any*/)/*: Query<
+export default ((node/*:: as any*/)/*:: as Query<
   IssueDetailCommentsQuery$variables,
   IssueDetailCommentsQuery$data,
 >*/);

--- a/issue-tracker/src/__generated__/IssueDetailComments_issue.graphql.js
+++ b/issue-tracker/src/__generated__/IssueDetailComments_issue.graphql.js
@@ -1,8 +1,7 @@
 /**
- * @generated SignedSource<<5cb8eef88a9b337ef2ae39ef1dd86a69>>
+ * @generated SignedSource<<105a925851bcae11191a8275b4d5f2b6>>
  * @flow
  * @lightSyntaxTransform
- * @nogrep
  */
 
 /* eslint-disable */
@@ -16,7 +15,7 @@ declare export opaque type IssueDetailComments_issue$fragmentType: FragmentType;
 type IssueDetailCommentsQuery$variables = any;
 export type IssueDetailComments_issue$data = {|
   +comments: {|
-    +edges: ?$ReadOnlyArray<?{|
+    +edges: ?ReadonlyArray<?{|
       +__id: string,
       +node: ?{|
         +author: ?{|
@@ -37,6 +36,8 @@ export type IssueDetailComments_issue$key = {
   ...
 };
 */
+
+import IssueDetailCommentsQuery_graphql from './IssueDetailCommentsQuery.graphql';
 
 var node/*: ReaderFragment*/ = (function(){
 var v0 = [
@@ -69,7 +70,7 @@ return {
         "count": "count",
         "cursor": "cursor",
         "direction": "forward",
-        "path": (v0/*: any*/)
+        "path": (v0/*:: as any*/)
       }
     ],
     "refetch": {
@@ -79,13 +80,16 @@ return {
           "cursor": "cursor"
         },
         "backward": null,
-        "path": (v0/*: any*/)
+        "path": (v0/*:: as any*/)
       },
       "fragmentPathInResult": [
         "node"
       ],
-      "operation": require('./IssueDetailCommentsQuery.graphql'),
-      "identifierField": "id"
+      "operation": IssueDetailCommentsQuery_graphql,
+      "identifierInfo": {
+        "identifierField": "id",
+        "identifierQueryVariableName": "id"
+      }
     }
   },
   "name": "IssueDetailComments_issue",
@@ -114,7 +118,7 @@ return {
               "name": "node",
               "plural": false,
               "selections": [
-                (v1/*: any*/),
+                (v1/*:: as any*/),
                 {
                   "alias": null,
                   "args": null,
@@ -207,16 +211,16 @@ return {
       ],
       "storageKey": null
     },
-    (v1/*: any*/)
+    (v1/*:: as any*/)
   ],
   "type": "Issue",
   "abstractKey": null
 };
 })();
 
-(node/*: any*/).hash = "674952f209c2653f27a5fad5539df511";
+(node/*:: as any*/).hash = "674952f209c2653f27a5fad5539df511";
 
-module.exports = ((node/*: any*/)/*: RefetchableFragment<
+export default ((node/*:: as any*/)/*:: as RefetchableFragment<
   IssueDetailComments_issue$fragmentType,
   IssueDetailComments_issue$data,
   IssueDetailCommentsQuery$variables,

--- a/issue-tracker/src/__generated__/IssueDetailRootQuery.graphql.js
+++ b/issue-tracker/src/__generated__/IssueDetailRootQuery.graphql.js
@@ -1,8 +1,7 @@
 /**
- * @generated SignedSource<<c8ec6403739d628287512607a8e6d45e>>
+ * @generated SignedSource<<dd778e1e527fe0eb2200b4c013965d90>>
  * @flow
  * @lightSyntaxTransform
- * @nogrep
  */
 
 /* eslint-disable */
@@ -11,13 +10,19 @@
 
 /*::
 import type { ConcreteRequest, Query } from 'relay-runtime';
-type IssueActions_issue$fragmentType = any;
-type IssueDetailComments_issue$fragmentType = any;
+import type { IssueActions_issue$fragmentType } from "./IssueActions_issue.graphql";
+import type { IssueDetailComments_issue$fragmentType } from "./IssueDetailComments_issue.graphql";
 export type IssueDetailRootQuery$variables = {|
   id: string,
 |};
 export type IssueDetailRootQuery$data = {|
   +node: ?{|
+    +IssueActions_issue?: ?{|
+      +$fragmentSpreads: IssueActions_issue$fragmentType,
+    |},
+    +IssueDetailComments_issue?: ?{|
+      +$fragmentSpreads: IssueDetailComments_issue$fragmentType,
+    |},
     +author?: ?{|
       +avatarUrl: any,
       +login: string,
@@ -27,7 +32,6 @@ export type IssueDetailRootQuery$data = {|
     +number?: number,
     +title?: string,
     +url?: any,
-    +$fragmentSpreads: IssueActions_issue$fragmentType & IssueDetailComments_issue$fragmentType,
   |},
 |};
 export type IssueDetailRootQuery = {|
@@ -122,13 +126,13 @@ v11 = {
   "name": "author",
   "plural": false,
   "selections": [
-    (v9/*: any*/),
-    (v4/*: any*/),
-    (v5/*: any*/),
+    (v9/*:: as any*/),
+    (v4/*:: as any*/),
+    (v5/*:: as any*/),
     {
       "kind": "InlineFragment",
       "selections": [
-        (v10/*: any*/)
+        (v10/*:: as any*/)
       ],
       "type": "Node",
       "abstractKey": "__isNode"
@@ -145,14 +149,14 @@ v12 = [
 ];
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0/*:: as any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "IssueDetailRootQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v1/*:: as any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
@@ -161,8 +165,8 @@ return {
           {
             "kind": "InlineFragment",
             "selections": [
-              (v2/*: any*/),
-              (v3/*: any*/),
+              (v2/*:: as any*/),
+              (v3/*:: as any*/),
               {
                 "alias": null,
                 "args": null,
@@ -171,22 +175,44 @@ return {
                 "name": "author",
                 "plural": false,
                 "selections": [
-                  (v4/*: any*/),
-                  (v5/*: any*/)
+                  (v4/*:: as any*/),
+                  (v5/*:: as any*/)
                 ],
                 "storageKey": null
               },
-              (v6/*: any*/),
-              (v7/*: any*/),
-              (v8/*: any*/),
+              (v6/*:: as any*/),
+              (v7/*:: as any*/),
+              (v8/*:: as any*/),
               {
-                "args": null,
-                "kind": "FragmentSpread",
+                "fragment": {
+                  "kind": "InlineFragment",
+                  "selections": [
+                    {
+                      "args": null,
+                      "kind": "FragmentSpread",
+                      "name": "IssueDetailComments_issue"
+                    }
+                  ],
+                  "type": "Issue",
+                  "abstractKey": null
+                },
+                "kind": "AliasedInlineFragmentSpread",
                 "name": "IssueDetailComments_issue"
               },
               {
-                "args": null,
-                "kind": "FragmentSpread",
+                "fragment": {
+                  "kind": "InlineFragment",
+                  "selections": [
+                    {
+                      "args": null,
+                      "kind": "FragmentSpread",
+                      "name": "IssueActions_issue"
+                    }
+                  ],
+                  "type": "Issue",
+                  "abstractKey": null
+                },
+                "kind": "AliasedInlineFragmentSpread",
                 "name": "IssueActions_issue"
               }
             ],
@@ -202,32 +228,32 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0/*:: as any*/),
     "kind": "Operation",
     "name": "IssueDetailRootQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v1/*:: as any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v9/*: any*/),
-          (v10/*: any*/),
+          (v9/*:: as any*/),
+          (v10/*:: as any*/),
           {
             "kind": "InlineFragment",
             "selections": [
-              (v2/*: any*/),
-              (v3/*: any*/),
-              (v11/*: any*/),
-              (v6/*: any*/),
-              (v7/*: any*/),
-              (v8/*: any*/),
+              (v2/*:: as any*/),
+              (v3/*:: as any*/),
+              (v11/*:: as any*/),
+              (v6/*:: as any*/),
+              (v7/*:: as any*/),
+              (v8/*:: as any*/),
               {
                 "alias": null,
-                "args": (v12/*: any*/),
+                "args": (v12/*:: as any*/),
                 "concreteType": "IssueCommentConnection",
                 "kind": "LinkedField",
                 "name": "comments",
@@ -249,10 +275,10 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v10/*: any*/),
-                          (v11/*: any*/),
-                          (v6/*: any*/),
-                          (v9/*: any*/)
+                          (v10/*:: as any*/),
+                          (v11/*:: as any*/),
+                          (v6/*:: as any*/),
+                          (v9/*:: as any*/)
                         ],
                         "storageKey": null
                       },
@@ -308,7 +334,7 @@ return {
               },
               {
                 "alias": null,
-                "args": (v12/*: any*/),
+                "args": (v12/*:: as any*/),
                 "filters": null,
                 "handle": "connection",
                 "key": "IssueDetailComments_comments",
@@ -335,9 +361,9 @@ return {
 };
 })();
 
-(node/*: any*/).hash = "42e7a1bc529086397c84040c8f84c752";
+(node/*:: as any*/).hash = "0f444943cee32f7cc6b39eedeeec926e";
 
-module.exports = ((node/*: any*/)/*: Query<
+export default ((node/*:: as any*/)/*:: as Query<
   IssueDetailRootQuery$variables,
   IssueDetailRootQuery$data,
 >*/);

--- a/issue-tracker/src/__generated__/IssuesListItem_issue.graphql.js
+++ b/issue-tracker/src/__generated__/IssuesListItem_issue.graphql.js
@@ -1,8 +1,7 @@
 /**
- * @generated SignedSource<<94a75a5609e86c2becbf290ec31293b8>>
+ * @generated SignedSource<<57f776a791ab461e30d9a99a1418105f>>
  * @flow
  * @lightSyntaxTransform
- * @nogrep
  */
 
 /* eslint-disable */
@@ -50,9 +49,9 @@ var node/*: ReaderFragment*/ = {
   "abstractKey": null
 };
 
-(node/*: any*/).hash = "4759ca84c6b2c9e515e40652369fe5a9";
+(node/*:: as any*/).hash = "4759ca84c6b2c9e515e40652369fe5a9";
 
-module.exports = ((node/*: any*/)/*: Fragment<
+export default ((node/*:: as any*/)/*:: as Fragment<
   IssuesListItem_issue$fragmentType,
   IssuesListItem_issue$data,
 >*/);

--- a/issue-tracker/src/__generated__/IssuesPaginationQuery.graphql.js
+++ b/issue-tracker/src/__generated__/IssuesPaginationQuery.graphql.js
@@ -1,8 +1,7 @@
 /**
- * @generated SignedSource<<dec4185007fec97aad954a53a9ae3969>>
+ * @generated SignedSource<<f38eced9e7e2fa93bf0b4a8aadac3667>>
  * @flow
  * @lightSyntaxTransform
- * @nogrep
  */
 
 /* eslint-disable */
@@ -12,13 +11,13 @@
 /*::
 import type { ConcreteRequest, Query } from 'relay-runtime';
 import type { FragmentType } from "relay-runtime";
-type Issues_repository$fragmentType = any;
+import type { Issues_repository$fragmentType } from "./Issues_repository.graphql";
 export type IssueState = "CLOSED" | "OPEN" | "%future added value";
 export type IssuesPaginationQuery$variables = {|
   count?: ?number,
   cursor?: ?string,
   id: string,
-  states?: ?$ReadOnlyArray<IssueState>,
+  states?: ?ReadonlyArray<IssueState>,
 |};
 export type IssuesPaginationQuery$data = {|
   +node: ?{|
@@ -89,15 +88,15 @@ v8 = [
     "name": "first",
     "variableName": "count"
   },
-  (v5/*: any*/)
+  (v5/*:: as any*/)
 ];
 return {
   "fragment": {
     "argumentDefinitions": [
-      (v0/*: any*/),
-      (v1/*: any*/),
-      (v2/*: any*/),
-      (v3/*: any*/)
+      (v0/*:: as any*/),
+      (v1/*:: as any*/),
+      (v2/*:: as any*/),
+      (v3/*:: as any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -105,7 +104,7 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v4/*: any*/),
+        "args": (v4/*:: as any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
@@ -123,7 +122,7 @@ return {
                 "name": "cursor",
                 "variableName": "cursor"
               },
-              (v5/*: any*/)
+              (v5/*:: as any*/)
             ],
             "kind": "FragmentSpread",
             "name": "Issues_repository"
@@ -138,30 +137,30 @@ return {
   "kind": "Request",
   "operation": {
     "argumentDefinitions": [
-      (v0/*: any*/),
-      (v1/*: any*/),
-      (v3/*: any*/),
-      (v2/*: any*/)
+      (v0/*:: as any*/),
+      (v1/*:: as any*/),
+      (v3/*:: as any*/),
+      (v2/*:: as any*/)
     ],
     "kind": "Operation",
     "name": "IssuesPaginationQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v4/*: any*/),
+        "args": (v4/*:: as any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v6/*: any*/),
-          (v7/*: any*/),
+          (v6/*:: as any*/),
+          (v7/*:: as any*/),
           {
             "kind": "InlineFragment",
             "selections": [
               {
                 "alias": null,
-                "args": (v8/*: any*/),
+                "args": (v8/*:: as any*/),
                 "concreteType": "IssueConnection",
                 "kind": "LinkedField",
                 "name": "issues",
@@ -183,7 +182,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v7/*: any*/),
+                          (v7/*:: as any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -191,7 +190,7 @@ return {
                             "name": "title",
                             "storageKey": null
                           },
-                          (v6/*: any*/)
+                          (v6/*:: as any*/)
                         ],
                         "storageKey": null
                       },
@@ -247,7 +246,7 @@ return {
               },
               {
                 "alias": null,
-                "args": (v8/*: any*/),
+                "args": (v8/*:: as any*/),
                 "filters": [
                   "states"
                 ],
@@ -276,9 +275,9 @@ return {
 };
 })();
 
-(node/*: any*/).hash = "5247d00636acb2216057e2b051be4a3c";
+(node/*:: as any*/).hash = "5247d00636acb2216057e2b051be4a3c";
 
-module.exports = ((node/*: any*/)/*: Query<
+export default ((node/*:: as any*/)/*:: as Query<
   IssuesPaginationQuery$variables,
   IssuesPaginationQuery$data,
 >*/);

--- a/issue-tracker/src/__generated__/Issues_repository.graphql.js
+++ b/issue-tracker/src/__generated__/Issues_repository.graphql.js
@@ -1,8 +1,7 @@
 /**
- * @generated SignedSource<<753282f23bc390ea70a915a27283949f>>
+ * @generated SignedSource<<c6767504ec079c25491db4f91dbd3cfe>>
  * @flow
  * @lightSyntaxTransform
- * @nogrep
  */
 
 /* eslint-disable */
@@ -11,14 +10,14 @@
 
 /*::
 import type { ReaderFragment, RefetchableFragment } from 'relay-runtime';
-type IssuesListItem_issue$fragmentType = any;
+import type { IssuesListItem_issue$fragmentType } from "./IssuesListItem_issue.graphql";
 import type { FragmentType } from "relay-runtime";
 declare export opaque type Issues_repository$fragmentType: FragmentType;
 type IssuesPaginationQuery$variables = any;
 export type Issues_repository$data = {|
   +id: string,
   +issues: {|
-    +edges: ?$ReadOnlyArray<?{|
+    +edges: ?ReadonlyArray<?{|
       +__id: string,
       +node: ?{|
         +$fragmentSpreads: IssuesListItem_issue$fragmentType,
@@ -33,6 +32,8 @@ export type Issues_repository$key = {
   ...
 };
 */
+
+import IssuesPaginationQuery_graphql from './IssuesPaginationQuery.graphql';
 
 var node/*: ReaderFragment*/ = (function(){
 var v0 = [
@@ -63,7 +64,7 @@ return {
         "count": "count",
         "cursor": "cursor",
         "direction": "forward",
-        "path": (v0/*: any*/)
+        "path": (v0/*:: as any*/)
       }
     ],
     "refetch": {
@@ -73,13 +74,16 @@ return {
           "cursor": "cursor"
         },
         "backward": null,
-        "path": (v0/*: any*/)
+        "path": (v0/*:: as any*/)
       },
       "fragmentPathInResult": [
         "node"
       ],
-      "operation": require('./IssuesPaginationQuery.graphql'),
-      "identifierField": "id"
+      "operation": IssuesPaginationQuery_graphql,
+      "identifierInfo": {
+        "identifierField": "id",
+        "identifierQueryVariableName": "id"
+      }
     }
   },
   "name": "Issues_repository",
@@ -192,9 +196,9 @@ return {
 };
 })();
 
-(node/*: any*/).hash = "5247d00636acb2216057e2b051be4a3c";
+(node/*:: as any*/).hash = "5247d00636acb2216057e2b051be4a3c";
 
-module.exports = ((node/*: any*/)/*: RefetchableFragment<
+export default ((node/*:: as any*/)/*:: as RefetchableFragment<
   Issues_repository$fragmentType,
   Issues_repository$data,
   IssuesPaginationQuery$variables,

--- a/issue-tracker/src/__generated__/RootQuery.graphql.js
+++ b/issue-tracker/src/__generated__/RootQuery.graphql.js
@@ -1,8 +1,7 @@
 /**
- * @generated SignedSource<<ffca303bd51487e7a9292cce9bf1688b>>
+ * @generated SignedSource<<0e02f3e7d770d997086354730bad8575>>
  * @flow
  * @lightSyntaxTransform
- * @nogrep
  */
 
 /* eslint-disable */
@@ -76,8 +75,8 @@ v5 = {
 return {
   "fragment": {
     "argumentDefinitions": [
-      (v0/*: any*/),
-      (v1/*: any*/)
+      (v0/*:: as any*/),
+      (v1/*:: as any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -85,7 +84,7 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v2/*: any*/),
+        "args": (v2/*:: as any*/),
         "concreteType": "Repository",
         "kind": "LinkedField",
         "name": "repository",
@@ -99,11 +98,11 @@ return {
             "name": "owner",
             "plural": false,
             "selections": [
-              (v3/*: any*/)
+              (v3/*:: as any*/)
             ],
             "storageKey": null
           },
-          (v4/*: any*/)
+          (v4/*:: as any*/)
         ],
         "storageKey": null
       }
@@ -114,15 +113,15 @@ return {
   "kind": "Request",
   "operation": {
     "argumentDefinitions": [
-      (v1/*: any*/),
-      (v0/*: any*/)
+      (v1/*:: as any*/),
+      (v0/*:: as any*/)
     ],
     "kind": "Operation",
     "name": "RootQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v2/*: any*/),
+        "args": (v2/*:: as any*/),
         "concreteType": "Repository",
         "kind": "LinkedField",
         "name": "repository",
@@ -143,13 +142,13 @@ return {
                 "name": "__typename",
                 "storageKey": null
               },
-              (v3/*: any*/),
-              (v5/*: any*/)
+              (v3/*:: as any*/),
+              (v5/*:: as any*/)
             ],
             "storageKey": null
           },
-          (v4/*: any*/),
-          (v5/*: any*/)
+          (v4/*:: as any*/),
+          (v5/*:: as any*/)
         ],
         "storageKey": null
       }
@@ -166,9 +165,9 @@ return {
 };
 })();
 
-(node/*: any*/).hash = "86d44615100f8e82c5a3ff63daa08bd5";
+(node/*:: as any*/).hash = "86d44615100f8e82c5a3ff63daa08bd5";
 
-module.exports = ((node/*: any*/)/*: Query<
+export default ((node/*:: as any*/)/*:: as Query<
   RootQuery$variables,
   RootQuery$data,
 >*/);

--- a/issue-tracker/yarn.lock
+++ b/issue-tracker/yarn.lock
@@ -1268,6 +1268,11 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.25.0":
+  version "7.29.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.2.tgz#9a6e2d05f4b6692e1801cd4fb176ad823930ed5e"
+  integrity sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==
+
 "@babel/template@^7.15.4", "@babel/template@^7.4.0", "@babel/template@^7.6.0", "@babel/template@^7.8.6":
   version "7.15.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.15.4.tgz#51898d35dcf3faa670c4ee6afcfd517ee139f194"
@@ -9455,16 +9460,16 @@ react-markdown@^4.2.2:
     unist-util-visit "^1.3.0"
     xtend "^4.0.1"
 
-react-relay@^14.0.0:
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/react-relay/-/react-relay-14.0.0.tgz#c9f9b8912bcef589782bea6a382548d55d20d522"
-  integrity sha512-zqT8ZS1lq24p1R8nW5Vi03oB1Ix8aYJxyuSl4bB8XDjSNL0kFuAdN8R5LrundUd3vuKjkV1UBfb1xuuoRroUhA==
+react-relay@^21.0.0:
+  version "21.0.0"
+  resolved "https://registry.yarnpkg.com/react-relay/-/react-relay-21.0.0.tgz#dab50d9a10f6e610148c01ea7941723717993c62"
+  integrity sha512-lGnL9lmDVIHX/mF4qFGC9DXIm26RqMDNI1lBoxrAYXtk7i1Llo1NB3aC0Rf7fRVq6MY3ycBC8eKdYTOmeLloaA==
   dependencies:
-    "@babel/runtime" "^7.0.0"
+    "@babel/runtime" "^7.25.0"
     fbjs "^3.0.2"
     invariant "^2.2.4"
     nullthrows "^1.1.1"
-    relay-runtime "14.0.0"
+    relay-runtime "21.0.0"
 
 react-router-config@^5.1.1:
   version "5.1.1"
@@ -9753,17 +9758,17 @@ relateurl@0.2.x:
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=
 
-relay-compiler@^14.0.0:
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/relay-compiler/-/relay-compiler-14.0.0.tgz#03ab000c246c7c46a26b77584b345621155a770e"
-  integrity sha512-1h4lwvHg5efhivqpMfG6SS4cGoCJH3BsRelihwD+GNiylBnLKArSE6zyW7LfEwSpuDfJ+l6rrRfSL8IVZwOZ0g==
+relay-compiler@^21.0.0:
+  version "21.0.0"
+  resolved "https://registry.yarnpkg.com/relay-compiler/-/relay-compiler-21.0.0.tgz#43e86ea95f51e441754efe1c5fe622688c35200a"
+  integrity sha512-ni8U67uybKAE1Aeh+tHw7Dmoeuvgm+UmEohJH8bAcoCnMkFX5Nj/6kGR/KyxcOSxdcXIkApAzurbXX+lUda6Wg==
 
-relay-runtime@14.0.0, relay-runtime@^14.0.0:
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/relay-runtime/-/relay-runtime-14.0.0.tgz#e2fa40d73569d2ba5810c773fb85ac872b08b5d0"
-  integrity sha512-Rnf6EgCl3QY85il/gTEh6GHAR9hoRkjYWgMR2Y3Afugb8qLR0vL6m/GBYqol8W3L8B+XqZ2U04/g624DRpEqAw==
+relay-runtime@21.0.0, relay-runtime@^21.0.0:
+  version "21.0.0"
+  resolved "https://registry.yarnpkg.com/relay-runtime/-/relay-runtime-21.0.0.tgz#2c9aaceb3464d39292b51fd4ffd08771082f11c6"
+  integrity sha512-CEKncRm8BOPT3IlymyfTVzQ8jNDgw0KrCAwel0QMG1R+ESpeMVTrWJzTGCjrzzT5MT2AEWZdCkClZ0JtXSKmUw==
   dependencies:
-    "@babel/runtime" "^7.0.0"
+    "@babel/runtime" "^7.25.0"
     fbjs "^3.0.2"
     invariant "^2.2.4"
 


### PR DESCRIPTION
## Summary
- Upgrade react-relay, relay-runtime, and relay-compiler from v14 to v21
- Add `@alias` to fragment spreads on concrete types within abstract type selections (required by Relay v21)
- Add `NODE_OPTIONS=--openssl-legacy-provider` to start script for react-scripts 3.2.0 / Node 17+ compatibility
- Regenerate all Relay compiler artifacts

## Screenshot
![issue-tracker running on localhost](https://github.com/user-attachments/assets/placeholder)

## Test plan
- [x] `relay-compiler` compiles without errors
- [x] App loads and displays issues from facebook/relay (see screenshot)
- [ ] Clicking an issue loads the detail page with comments
- [ ] "Load More" pagination works