### PR TITLE
Fix data-driven-dependencies example app

### DIFF
--- a/data-driven-dependencies/.env
+++ b/data-driven-dependencies/.env
@@ -1,1 +1,1 @@
-GRAPHQL_ENDPOINT=http://localhost:3000/api/graphql
+

--- a/data-driven-dependencies/lib/relay/network.js
+++ b/data-driven-dependencies/lib/relay/network.js
@@ -44,7 +44,7 @@ export async function networkFetch(id, variables) {
   const response = await fetch(
     // TODO: figure out how not to use hardcoded hostname and port
     // TODO: consider bypassing api fetch and directly invoking graphql on server
-    process.env.GRAPHQL_ENDPOINT ?? 'http://localhost:3000/api/graphql',
+    `http://localhost:${process.env.PORT ?? 3000}/api/graphql`,
     {
       method: 'POST',
       headers: {

--- a/data-driven-dependencies/next.config.js
+++ b/data-driven-dependencies/next.config.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const relay = require('./relay.config.json');
 
 module.exports = {
@@ -14,5 +15,13 @@ module.exports = {
   },
   serverRuntimeConfig: {
     projectRoot: __dirname,
+  },
+  webpack(config) {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      react: path.resolve(__dirname, 'node_modules', 'react'),
+      'react-dom': path.resolve(__dirname, 'node_modules', 'react-dom'),
+    };
+    return config;
   },
 };


### PR DESCRIPTION
## Summary
- Remove hardcoded `GRAPHQL_ENDPOINT` env var and instead construct the URL from `PORT`, falling back to 3000
- Add webpack alias for `react` and `react-dom` to resolve duplicate React instances when using linked packages
- Import `path` module in `next.config.js` for the alias resolution

## Test plan
- [ ] Run `yarn install` and `yarn dev` in `data-driven-dependencies/`
- [ ] Verify the app starts and loads correctly on the default port
- [ ] Verify setting a custom `PORT` env var is respected